### PR TITLE
fix(data-marts): calculated field improvements

### DIFF
--- a/.changeset/6876-calculated-field-improvements.md
+++ b/.changeset/6876-calculated-field-improvements.md
@@ -1,0 +1,19 @@
+---
+'owox': minor
+---
+
+# Calculated Field improvements
+
+Six changes to the Calculated Field editor, from feedback on the released version.
+
+**A row-level field keeps its "Σ available" control while its formula is edited.** Touching the formula of a calculated field that is a dimension took that control off the row until the schema was saved, which read as the setting having been lost.
+
+**Unsaved edits survive a background refresh.** The Output Schema editor reset itself whenever the Data Mart was re-read — which happens on its own, without anyone asking — and a formula typed but not yet saved went with it, while a failed save's errors stayed on screen naming a field no longer in the table. It now resets only when the saved schema has actually changed.
+
+**A rejected formula is named where the refusal appears.** Choosing "Save & leave" on the unsaved-changes prompt reported `Request failed with status code 400`, which names neither the field nor the fix. It now names the field the warehouse rejected.
+
+**A calculated field no longer stretches its row.** A formula written over several lines made its row that many lines tall. The row now shows at most two lines — the most it can show without growing — and hovering it shows the whole formula with the author's own line breaks.
+
+**The division warning is about the formula in front of you.** It quoted `NULLIF(SUM(impressions), 0)` whether or not `impressions` appeared anywhere in the formula, and read like a refusal although it blocks nothing. It now quotes the denominator this formula actually divides by, underlines it in the editor, and says plainly that it is advice. It quotes the whole denominator or nothing at all — never a piece of one, since guarding a piece leaves the division just as broken and silences the warning.
+
+**`COALESCE` no longer counts as a guard against that division.** What fails a query is a zero denominator, not a null one — and `COALESCE(SUM(x), 0)` produces exactly the zero that fails it. Accepting it meant agreeing with a formula that had guarded nothing. The message and [the setup guide](https://docs.owox.com/docs/getting-started/setup-guide/calculated-fields/) now say zero rather than "zero or empty", and the guide explains why `COALESCE` does not count. The guide also gains a worked example for rates over a condition, such as an activation rate.

--- a/apps/backend/src/data-marts/calculated-fields/formula-analyzer.spec.ts
+++ b/apps/backend/src/data-marts/calculated-fields/formula-analyzer.spec.ts
@@ -393,6 +393,34 @@ describe('analyzeFormula', () => {
     expect(warning?.message).toContain('does not block the save');
   });
 
+  // Stepping past the parens to test the FIRST token called `(1 - rate)` a constant and went
+  // quiet — on a shape common enough to matter. The whole group has to be constant to say that.
+  it.each([
+    ['(-1 + {{ref field="b"}})', '(-1 + b)'],
+    ['(1 - {{ref field="rate"}})', '(1 - rate)'],
+  ])('warns about the non-constant group %s', (group, expected) => {
+    const a = analyze(`SUM({{ref field="a"}}) / ${group}`);
+    expect(a.warnings[0].code).toBe('FORMULA_UNGUARDED_DIVISION');
+    expect(a.warnings[0].subject).toBe(expected);
+  });
+
+  it('stays silent on a group that really is constant', () => {
+    expect(analyze('SUM({{ref field="a"}}) / (2)').warnings).toEqual([]);
+  });
+
+  // Same rule as everywhere else here: a subject that cannot be quoted honestly is not quoted. A
+  // comment's terminating newline folds into a space, so the advice would paste as broken SQL; a
+  // quoted identifier brings its own delimiters, which the message's backticks would double.
+  it.each([
+    ['a comment', 'SUM({{ref field="a"}}) / ({{ref field="b"}} -- note\n + 1)'],
+    ['a quoted identifier', 'SUM({{ref field="a"}}) / "weird col"'],
+  ])('warns without naming a denominator holding %s', (_case, formula) => {
+    const a = analyze(formula);
+    const warning = a.warnings.find(w => w.code === 'FORMULA_UNGUARDED_DIVISION');
+    expect(warning).toBeDefined();
+    expect(warning?.subject).toBeUndefined();
+  });
+
   // A constant denominator cannot come out zero unless it IS zero, and the sign is part of the
   // constant. Without stepping over it the scan landed on the sign and quoted `-`.
   it.each(['-1', '+ 2', '- 0.5'])('stays silent on the constant denominator %s', constant => {

--- a/apps/backend/src/data-marts/calculated-fields/formula-analyzer.spec.ts
+++ b/apps/backend/src/data-marts/calculated-fields/formula-analyzer.spec.ts
@@ -301,13 +301,60 @@ describe('analyzeFormula', () => {
     expect(a.warnings[0].code).toBe('FORMULA_UNGUARDED_DIVISION');
   });
 
+  // The message has to name THIS formula's denominator. It used to carry a fixed example naming a
+  // column the analyst was not looking at, which reads as advice about somebody else's formula.
+  it('names the denominator it is actually warning about', () => {
+    const a = analyze('SUM({{ref field="a"}}) / SUM({{ref field="b"}})');
+    expect(a.warnings[0].subject).toBe('SUM(b)');
+    expect(a.warnings[0].message).toContain('`SUM(b)` can come out ZERO');
+    expect(a.warnings[0].message).toContain('NULLIF(SUM(b), 0)');
+  });
+
+  // The analyzer only holds the STORED form; quoting it verbatim would show a `{{ref}}` tag, which
+  // the editor deliberately never displays.
+  it('writes the denominator the way the analyst sees it, never as a tag', () => {
+    const a = analyze('SUM({{ref field="a"}}) / SUM({{ref path="orders" field="amount"}})');
+    expect(a.warnings[0].subject).toBe('SUM(orders.amount)');
+    expect(a.warnings[0].message).not.toContain('{{ref');
+  });
+
+  // A tag is punctuation to the scanner, so a BARE reference as the denominator starts at its `{`
+  // and was quoted as a single brace.
+  it('names a bare reference denominator, not the brace it starts with', () => {
+    const a = analyze('{{ref field="revenue"}} / {{ref field="cost"}}');
+    expect(a.warnings[0].subject).toBe('cost');
+    expect(a.warnings[0].message).toContain('NULLIF(cost, 0)');
+  });
+
+  // The one violation in the catalogue that refuses nothing. A reader who cannot tell it apart from
+  // the ones that do treats a saveable formula as broken.
+  it('says it does not block the save', () => {
+    const a = analyze('SUM({{ref field="a"}}) / SUM({{ref field="b"}})');
+    expect(a.warnings[0].message).toContain('does not block the save');
+  });
+
+  // COALESCE replaces a NULL, and a NULL denominator is harmless — `1 / CAST(NULL AS INT64)` is
+  // NULL on BigQuery and raises nothing. `1 / 0` is what fails the statement, and
+  // `COALESCE(SUM(x), 0)` is a machine for producing exactly that zero (verified: it raises
+  // `division by zero`). Accepting it as a guard agreed with an analyst who had guarded nothing.
+  it('does not accept COALESCE as a guard, which replaces a null rather than a zero', () => {
+    const a = analyze('SUM({{ref field="a"}}) / COALESCE(SUM({{ref field="b"}}), 0)');
+    expect(a.warnings.map(w => w.code)).toEqual(['FORMULA_UNGUARDED_DIVISION']);
+  });
+
+  it('warns about the zero, never about a null', () => {
+    const a = analyze('SUM({{ref field="a"}}) / SUM({{ref field="b"}})');
+    expect(a.warnings[0].message).toContain('come out ZERO');
+    expect(a.warnings[0].message).not.toContain('empty denominator');
+  });
+
   it('does not warn when the denominator is guarded', () => {
     expect(analyze('SUM({{ref field="a"}}) / NULLIF(SUM({{ref field="b"}}), 0)').warnings).toEqual(
       []
     );
   });
 
-  // The example the policy comment above `hasUnguardedDivision` names in full: a guard around the
+  // The example the policy comment above `unguardedDenominator` names in full: a guard around the
   // QUOTIENT is not a guard on the denominator, and the analyst still divides by zero. Pinned
   // because a containment test passes every other case here while silently accepting this one.
   it('still warns when the guard wraps the quotient rather than the denominator', () => {
@@ -319,6 +366,37 @@ describe('analyzeFormula', () => {
     expect(
       analyze('SUM({{ref field="a"}}) / (NULLIF(SUM({{ref field="b"}}), 0))').warnings
     ).toEqual([]);
+  });
+
+  // Naming a FRAGMENT of the denominator is worse than naming nothing. An analyst who wraps what
+  // the message quotes gets `revenue / (NULLIF(cost, 0) + tax)` — still fatal when `cost + tax` is
+  // zero, and now silent, because the guard sits exactly where this scan looks.
+  it('names a parenthesised denominator whole, not its first operand', () => {
+    const a = analyze('{{ref field="revenue"}} / ({{ref field="cost"}} + {{ref field="tax"}})');
+    expect(a.warnings[0].subject).toBe('(cost + tax)');
+    expect(a.warnings[0].message).toContain('NULLIF((cost + tax), 0)');
+  });
+
+  // Same rule where no span stands for the denominator at all: the warning is still true, so it
+  // stays — it just stops pointing at the wrong token.
+  it.each([
+    [
+      'a CASE expression',
+      'SUM({{ref field="a"}}) / CASE WHEN {{ref field="b"}} > 0 THEN 1 ELSE 2 END',
+    ],
+    ['an unclosed call', 'SUM({{ref field="a"}}) / SUM({{ref field="b"}}'],
+  ])('warns without naming anything when the denominator is %s', (_case, formula) => {
+    const a = analyze(formula);
+    const warning = a.warnings.find(w => w.code === 'FORMULA_UNGUARDED_DIVISION');
+    expect(warning).toBeDefined();
+    expect(warning?.subject).toBeUndefined();
+    expect(warning?.message).toContain('does not block the save');
+  });
+
+  // A constant denominator cannot come out zero unless it IS zero, and the sign is part of the
+  // constant. Without stepping over it the scan landed on the sign and quoted `-`.
+  it.each(['-1', '+ 2', '- 0.5'])('stays silent on the constant denominator %s', constant => {
+    expect(analyze(`SUM({{ref field="a"}}) / ${constant}`).warnings).toEqual([]);
   });
 
   it('does not warn when the denominator is a numeric literal', () => {

--- a/apps/backend/src/data-marts/calculated-fields/formula-analyzer.ts
+++ b/apps/backend/src/data-marts/calculated-fields/formula-analyzer.ts
@@ -291,8 +291,9 @@ export function analyzeFormula(input: AnalyzeFormulaInput): FormulaAnalysis {
     }
   }
 
-  if (hasUnguardedDivision(tokens, calls)) {
-    warnings.push(FormulaViolations.unguardedDivision(fieldName));
+  const division = unguardedDenominator(formula, tokens, calls, references);
+  if (division) {
+    warnings.push(FormulaViolations.unguardedDivision(fieldName, division.subject));
   }
 
   return {
@@ -365,32 +366,111 @@ function dedupeViolations(violations: FormulaViolation[]): FormulaViolation[] {
 }
 
 /**
- * A `/` whose right-hand side is neither a numeric literal nor already wrapped in a null-guarding
- * call. Deliberately shallow — an advisory, not a correctness gate. Known gaps, left for a human:
- * a guard around the RESULT of the division still warns, because it does not guard the denominator;
- * IF and CASE guards are not recognised; the guard-function set is fixed rather than per dialect.
+ * A `/` whose right-hand side is neither a numeric literal nor already wrapped in a call that turns
+ * a ZERO denominator into something harmless.
+ *
+ * Zero, not null. Measured on BigQuery: `1 / CAST(NULL AS INT64)` is NULL and raises nothing, while
+ * `1 / 0` fails the statement. So COALESCE is NOT in the guard set — it replaces a null, which was
+ * never the danger, and `COALESCE(SUM(x), 0)` actively PRODUCES the zero that fails the query
+ * (verified: `1 / COALESCE(CAST(NULL AS INT64), 0)` raises `division by zero`). Accepting it meant
+ * agreeing with an analyst who believed they had guarded.
+ *
+ * Deliberately shallow — an advisory, not a correctness gate. Known gaps, all erring toward warning
+ * rather than staying silent: a guard around the RESULT of the division still warns, because it does
+ * not guard the denominator; a guard NESTED inside the denominator (`COALESCE(NULLIF(x, 0), 1)`)
+ * warns too; IF and CASE guards are not recognised; the guard set is fixed rather than per dialect.
  */
-function hasUnguardedDivision(
+interface UnguardedDivision {
+  /** The span to quote, or absent when nothing in the formula stands for the whole denominator. */
+  subject?: string;
+}
+
+function unguardedDenominator(
+  formula: string,
   tokens: readonly SqlToken[],
-  calls: readonly SqlFunctionCall[]
-): boolean {
-  const GUARDS = new Set(['NULLIF', 'SAFE_DIVIDE', 'IFF', 'COALESCE', 'NULLIFZERO', 'DIV0']);
+  calls: readonly SqlFunctionCall[],
+  references: readonly FormulaReference[]
+): UnguardedDivision | undefined {
+  const GUARDS = new Set(['NULLIF', 'SAFE_DIVIDE', 'IFF', 'NULLIFZERO', 'DIV0']);
   const code = tokens.filter(t => t.kind !== 'comment');
-  return code.some((token, i) => {
-    if (!(token.kind === 'punct' && token.value === '/')) return false;
+  for (const [i, token] of code.entries()) {
+    if (!(token.kind === 'punct' && token.value === '/')) continue;
     // Past any parens the analyst wrapped the denominator in, so `a / (NULLIF(b, 0))` reads the
-    // same as `a / NULLIF(b, 0)`.
+    // same as `a / NULLIF(b, 0)` — and past a unary sign, so `a / -1` reads like `a / 1` and is
+    // dropped as the constant it is.
     let j = i + 1;
-    while (code[j]?.kind === 'punct' && code[j].value === '(') j++;
+    let group: SqlToken | undefined;
+    while (code[j]?.kind === 'punct' && ['(', '-', '+'].includes(code[j].value)) {
+      if (code[j].value === '(') group ??= code[j];
+      j++;
+    }
     const denominator = code[j];
-    if (!denominator) return false;
-    if (denominator.kind === 'number') return false;
+    if (!denominator) continue;
+    if (denominator.kind === 'number') continue;
     // The denominator must BE the guard call. Asking only that it fall somewhere INSIDE one also
     // accepts a guard wrapped around the whole quotient — the case the policy above says still
     // warns, because a guard on the result does nothing about dividing by zero.
-    const guarded = calls.some(
-      c => GUARDS.has(c.name.toUpperCase()) && c.nameStart === denominator.start
-    );
-    return !guarded;
-  });
+    const call = calls.find(c => c.nameStart === denominator.start);
+    if (call && GUARDS.has(call.name.toUpperCase())) continue;
+
+    // What to NAME is a separate question from whether to warn, and naming the wrong thing is
+    // worse than naming nothing: an analyst who wraps what the message quotes in `NULLIF` ends up
+    // with a formula that still divides by zero AND no longer warns, because the guard now sits
+    // where this scan looks. So the subject is only ever a span that stands for the whole
+    // denominator.
+    if (group) {
+      // A parenthesised denominator is that whole group: `a / (cost + tax)` is guarded by wrapping
+      // the SUM, never by wrapping `cost`.
+      const close = matchingParen(code, group);
+      return { subject: close && authoringText(formula, references, group.start, close.end) };
+    }
+    // A `{{ref}}` tag is punctuation to the scanner, so a bare reference as the denominator starts
+    // at its `{` and would be quoted as one brace. Its own span is the thing to name.
+    const ref = references.find(r => r.start <= denominator.start && denominator.start < r.end);
+    if (ref) return { subject: authoringText(formula, references, ref.start, ref.end) };
+    if (call?.closed) {
+      return { subject: authoringText(formula, references, denominator.start, call.argEnd + 1) };
+    }
+    if (denominator.kind === 'quotedIdentifier') {
+      return { subject: authoringText(formula, references, denominator.start, denominator.end) };
+    }
+    // A bare word (`CASE`), an unclosed call, a stray operator: the token is a fragment of the
+    // denominator rather than the denominator, so the warning stands without pointing at it.
+    return {};
+  }
+  return undefined;
+}
+
+/** The `)` closing `open`, or undefined if the formula never closes it. */
+function matchingParen(code: readonly SqlToken[], open: SqlToken): SqlToken | undefined {
+  let depth = 0;
+  for (const token of code) {
+    if (token.start < open.start || token.kind !== 'punct') continue;
+    if (token.value === '(') depth++;
+    else if (token.value === ')' && --depth === 0) return token;
+  }
+  return undefined;
+}
+
+/**
+ * A slice of the STORED formula written the way the analyst sees it — every `{{ref}}` tag inside it
+ * replaced by the name it stands for.
+ *
+ * The analyzer only ever holds the stored form, and a message quoting that verbatim would show a tag
+ * the editor deliberately never displays.
+ */
+function authoringText(
+  formula: string,
+  references: readonly FormulaReference[],
+  start: number,
+  end: number
+): string {
+  const inside = references
+    .filter(r => start <= r.start && r.end <= end)
+    .sort((a, b) => b.start - a.start);
+  let text = formula.slice(start, end);
+  for (const ref of inside) {
+    text = text.slice(0, ref.start - start) + refLabel(ref) + text.slice(ref.end - start);
+  }
+  return text.replace(/\s+/g, ' ').trim();
 }

--- a/apps/backend/src/data-marts/calculated-fields/formula-analyzer.ts
+++ b/apps/backend/src/data-marts/calculated-fields/formula-analyzer.ts
@@ -1,6 +1,7 @@
 import {
   FormulaReference,
   parseFormulaReferences,
+  renderFormula,
   FormulaReferenceSyntaxError,
 } from './formula-reference';
 import { scanSql, SqlToken } from './sql-token-scanner';
@@ -393,11 +394,42 @@ function unguardedDenominator(
 ): UnguardedDivision | undefined {
   const GUARDS = new Set(['NULLIF', 'SAFE_DIVIDE', 'IFF', 'NULLIFZERO', 'DIV0']);
   const code = tokens.filter(t => t.kind !== 'comment');
+
+  /**
+   * The span, written as the analyst sees it — unless it cannot be quoted honestly.
+   *
+   * A comment inside it survives the slice and the whitespace collapse folds the newline that ends
+   * it, so `NULLIF((b -- note + 1), 0)` is what the advice would say: broken SQL when pasted. A
+   * quoted identifier arrives with its own delimiters, which the message's backticks would then
+   * double — unreadable to the web's leading-backtick parser, and unmarkable in an editor that
+   * masks quoted spans before searching. Both take the unnamed message, which reads fine.
+   */
+  const named = (from: number, to: number): UnguardedDivision => {
+    // A `{{ref}}` tag's own `"field"` scans as a quoted identifier, so tokens inside a tag are
+    // excluded — they are the tag's syntax, not text the analyst wrote.
+    const insideTag = (t: SqlToken) => references.some(r => r.start <= t.start && t.end <= r.end);
+    const unquotable = tokens.some(
+      t =>
+        t.start >= from &&
+        t.end <= to &&
+        !insideTag(t) &&
+        (t.kind === 'comment' || t.kind === 'quotedIdentifier')
+    );
+    if (unquotable) return {};
+    try {
+      return { subject: authoringText(formula, from, to) };
+    } catch {
+      // A span holding half a `{{ref}}` tag cannot be rendered. Not reachable from the spans below,
+      // which are all tag-aligned, but this runs inside the editor's live check: a throw here would
+      // silence every diagnostic rather than lose one subject.
+      return {};
+    }
+  };
+
   for (const [i, token] of code.entries()) {
     if (!(token.kind === 'punct' && token.value === '/')) continue;
     // Past any parens the analyst wrapped the denominator in, so `a / (NULLIF(b, 0))` reads the
-    // same as `a / NULLIF(b, 0)` — and past a unary sign, so `a / -1` reads like `a / 1` and is
-    // dropped as the constant it is.
+    // same as `a / NULLIF(b, 0)` — and past a unary sign, so `a / -1` reads like `a / 1`.
     let j = i + 1;
     let group: SqlToken | undefined;
     while (code[j]?.kind === 'punct' && ['(', '-', '+'].includes(code[j].value)) {
@@ -406,7 +438,13 @@ function unguardedDenominator(
     }
     const denominator = code[j];
     if (!denominator) continue;
-    if (denominator.kind === 'number') continue;
+    const close = group && matchingParen(code, group);
+    // A constant cannot come out zero unless it IS zero. Inside a group the whole group has to be
+    // constant to say that: `(2)` is, `(1 - rate)` is not, and testing only the first token called
+    // both of them constants.
+    if (group ? close && isConstantGroup(code, group, close) : denominator.kind === 'number') {
+      continue;
+    }
     // The denominator must BE the guard call. Asking only that it fall somewhere INSIDE one also
     // accepts a guard wrapped around the whole quotient — the case the policy above says still
     // warns, because a guard on the result does nothing about dividing by zero.
@@ -416,29 +454,30 @@ function unguardedDenominator(
     // What to NAME is a separate question from whether to warn, and naming the wrong thing is
     // worse than naming nothing: an analyst who wraps what the message quotes in `NULLIF` ends up
     // with a formula that still divides by zero AND no longer warns, because the guard now sits
-    // where this scan looks. So the subject is only ever a span that stands for the whole
-    // denominator.
+    // where this scan looks. So the subject is only ever a span standing for the WHOLE denominator.
     if (group) {
-      // A parenthesised denominator is that whole group: `a / (cost + tax)` is guarded by wrapping
-      // the SUM, never by wrapping `cost`.
-      const close = matchingParen(code, group);
-      return { subject: close && authoringText(formula, references, group.start, close.end) };
+      // `a / (cost + tax)` is guarded by wrapping the sum, never by wrapping `cost`.
+      return close ? named(group.start, close.end) : {};
     }
     // A `{{ref}}` tag is punctuation to the scanner, so a bare reference as the denominator starts
     // at its `{` and would be quoted as one brace. Its own span is the thing to name.
     const ref = references.find(r => r.start <= denominator.start && denominator.start < r.end);
-    if (ref) return { subject: authoringText(formula, references, ref.start, ref.end) };
-    if (call?.closed) {
-      return { subject: authoringText(formula, references, denominator.start, call.argEnd + 1) };
-    }
-    if (denominator.kind === 'quotedIdentifier') {
-      return { subject: authoringText(formula, references, denominator.start, denominator.end) };
-    }
+    if (ref) return named(ref.start, ref.end);
+    if (call?.closed) return named(denominator.start, call.argEnd + 1);
     // A bare word (`CASE`), an unclosed call, a stray operator: the token is a fragment of the
     // denominator rather than the denominator, so the warning stands without pointing at it.
     return {};
   }
   return undefined;
+}
+
+/** Whether everything between `open` and `close` is a numeric literal or a sign on one. */
+function isConstantGroup(code: readonly SqlToken[], open: SqlToken, close: SqlToken): boolean {
+  return code
+    .filter(t => t.start >= open.end && t.end <= close.start)
+    .every(
+      t => t.kind === 'number' || (t.kind === 'punct' && ['+', '-', '(', ')'].includes(t.value))
+    );
 }
 
 /** The `)` closing `open`, or undefined if the formula never closes it. */
@@ -459,18 +498,9 @@ function matchingParen(code: readonly SqlToken[], open: SqlToken): SqlToken | un
  * The analyzer only ever holds the stored form, and a message quoting that verbatim would show a tag
  * the editor deliberately never displays.
  */
-function authoringText(
-  formula: string,
-  references: readonly FormulaReference[],
-  start: number,
-  end: number
-): string {
-  const inside = references
-    .filter(r => start <= r.start && r.end <= end)
-    .sort((a, b) => b.start - a.start);
-  let text = formula.slice(start, end);
-  for (const ref of inside) {
-    text = text.slice(0, ref.start - start) + refLabel(ref) + text.slice(ref.end - start);
-  }
-  return text.replace(/\s+/g, ' ').trim();
+function authoringText(formula: string, start: number, end: number): string {
+  // The same renderer the rest of the feature uses, rather than a second substitution loop for the
+  // two to drift apart on. Every span passed here contains whole tags, which is what lets a SLICE
+  // be re-parsed on its own.
+  return renderFormula(formula.slice(start, end), refLabel).replace(/\s+/g, ' ').trim();
 }

--- a/apps/backend/src/data-marts/calculated-fields/formula-violations.spec.ts
+++ b/apps/backend/src/data-marts/calculated-fields/formula-violations.spec.ts
@@ -37,7 +37,7 @@ const built: Record<string, FormulaViolation> = {
   mainUniqueCountReference: FormulaViolations.mainUniqueCountReference('ctr', 'unique_count'),
   tagInStringLiteral: FormulaViolations.tagInStringLiteral('ctr'),
   syntax: FormulaViolations.syntax('ctr', 'something could not be parsed'),
-  unguardedDivision: FormulaViolations.unguardedDivision('ctr'),
+  unguardedDivision: FormulaViolations.unguardedDivision('ctr', 'SUM(impressions)'),
   warehouseRejected: FormulaViolations.warehouseRejected('ctr', 'Unrecognized name: clcks'),
   warehouseRejectedAsSet: FormulaViolations.warehouseRejectedAsSet('ctr', 'alias collision'),
   otherFieldErrorsTruncated: FormulaViolations.otherFieldErrorsTruncated('ctr', 12),
@@ -114,6 +114,7 @@ describe('FormulaViolations', () => {
         'nestedAggregate',
         'selfReference',
         'unbalancedParenthesis',
+        'unguardedDivision',
         'unknownReference',
       ].sort()
     );

--- a/apps/backend/src/data-marts/calculated-fields/formula-violations.ts
+++ b/apps/backend/src/data-marts/calculated-fields/formula-violations.ts
@@ -312,12 +312,26 @@ export const FormulaViolations = {
     field,
     message: detail,
   }),
-  unguardedDivision: (field: string): FormulaViolation => ({
+  // ADVICE, and the message has to say so: this is the only violation in the catalogue that does
+  // not refuse anything, and a reader who cannot tell it from the ones that do treats a saveable
+  // formula as broken. The example is built from THIS formula's own denominator rather than from a
+  // fixed one, which named a column the analyst was not looking at.
+  // `denominator` is omitted when nothing in the formula stands for the WHOLE denominator — a
+  // `CASE`, an unclosed call. Quoting a fragment would be worse than quoting nothing: wrapping it
+  // in NULLIF leaves the division just as unguarded and moves the guard to where the check looks,
+  // so the next save says nothing at all.
+  unguardedDivision: (field: string, denominator?: string): FormulaViolation => ({
     code: 'FORMULA_UNGUARDED_DIVISION',
     field,
-    message:
-      'This formula divides without guarding against a zero or empty denominator. ' +
-      'Wrap it, e.g. NULLIF(SUM(impressions), 0).',
+    ...(denominator ? { subject: denominator } : {}),
+    message: denominator
+      ? `\`${denominator}\` can come out ZERO, and dividing by zero fails the whole report at the ` +
+        `warehouse rather than leaving one cell blank. Wrap it as NULLIF(${denominator}, 0), which ` +
+        `turns the zero into an empty cell. Advice only: this does not block the save.`
+      : `This formula divides by something that can come out ZERO, and dividing by zero fails the ` +
+        `whole report at the warehouse rather than leaving one cell blank. Wrap the denominator as ` +
+        `NULLIF(it, 0), which turns the zero into an empty cell. Advice only: this does not block ` +
+        `the save.`,
   }),
   // Used by the dry-run pass. Defined here so every message this feature can emit
   // lives in one file.

--- a/apps/web/e2e/helpers/formula-cell.ts
+++ b/apps/web/e2e/helpers/formula-cell.ts
@@ -1,0 +1,17 @@
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * The Output Schema row cell showing `formula`.
+ *
+ * The cell used to carry the whole formula as its `title`, which is what these specs located it
+ * by. It no longer does: the row shows a clamped preview and the full formula moved into a hover
+ * card, and a native tooltip alongside that card would be a second, worse telling of the same
+ * thing. The cell is the card's trigger, so the slot Radix puts there is what identifies it now.
+ *
+ * Matched on the cell's EXACT text rather than a substring, because one fixture formula is a
+ * substring of another (`SUM(clicks)` inside the long one).
+ */
+export function findFormulaCell(page: Page, formula: string): Locator {
+  const exact = new RegExp(`^${formula.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
+  return page.locator('[data-slot="hover-card-trigger"]').filter({ hasText: exact }).first();
+}

--- a/apps/web/e2e/specs/datamart-calculated-field-chips.spec.ts
+++ b/apps/web/e2e/specs/datamart-calculated-field-chips.spec.ts
@@ -494,7 +494,14 @@ test.describe('Data Setup - Calculated field chips', () => {
     // Mixing the two levels is what is still refused, and it is refused about a FIELD, which is
     // what this test needs: a violation about a function or about the formula as a whole marks no
     // chip.
-    await page.keyboard.type(' + clicks');
+    // Typed at a human pace, and asserted before the check is asked about it. Every other burst in
+    // this file is a single character; this one is nine, and fired as fast as CDP allows it
+    // outruns the editor on a loaded machine — CI lost `clic` out of the middle and sent
+    // `SUM(clicks) + ks`, a formula with nothing wrong in it, so the assertion below waited 15s
+    // for a diagnostic that was never coming. Polling the text first says that in one line.
+    await page.keyboard.type(' + clicks', { delay: 25 });
+    await expect.poll(formulaText(page)).toBe('SUM(clicks) + clicks');
+
     await expect(page.getByTestId('formula-diagnostics')).toContainText('row-level column', {
       timeout: 15000,
     });

--- a/apps/web/e2e/specs/datamart-calculated-field-chips.spec.ts
+++ b/apps/web/e2e/specs/datamart-calculated-field-chips.spec.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 import { test, expect } from '../fixtures/base';
 import { TESTIDS } from '../selectors/testids';
+import { findFormulaCell } from '../helpers/formula-cell';
 
 // ---------------------------------------------------------------------------
 // DSET-10: a resolved field reference behaves as an ATOMIC CHIP.
@@ -158,7 +159,7 @@ test.describe('Data Setup - Calculated field chips', () => {
     await page.goto(`/ui/0/data-marts/${dataMartId}/data-setup`);
     await expect(page.getByTestId(TESTIDS.datamartTabDataSetup)).toBeVisible();
 
-    const formulaCell = page.locator(`[title="${formula}"]`).first();
+    const formulaCell = findFormulaCell(page, formula);
     await expect(formulaCell).toBeVisible({ timeout: 15000 });
     await formulaCell.click();
 
@@ -180,7 +181,7 @@ test.describe('Data Setup - Calculated field chips', () => {
     await page.goto(`/ui/0/data-marts/${dataMartId}/data-setup`);
     await expect(page.getByTestId(TESTIDS.datamartTabDataSetup)).toBeVisible();
 
-    const cell = page.locator(`[title="${METRIC_FORMULA}"]`).first();
+    const cell = findFormulaCell(page, METRIC_FORMULA);
     await expect(cell).toBeVisible({ timeout: 15000 });
 
     const chip = cell.locator(CHIP);
@@ -587,11 +588,11 @@ test.describe('Data Setup - Calculated field chips', () => {
     await page.goto(`/ui/0/data-marts/${dataMartId}/data-setup`);
     await expect(page.getByTestId(TESTIDS.datamartTabDataSetup)).toBeVisible();
 
-    const cell = page.locator(`[title="${JOINED_FORMULA}"]`).first();
+    const cell = findFormulaCell(page, JOINED_FORMULA);
     await expect(cell).toBeVisible({ timeout: 15000 });
 
-    // The cell carries the whole formula as its title; the pill's own title has to win over it,
-    // which is what a hover on the pill actually shows.
+    // The pill carries its own answer, which is what a hover on the pill actually shows. The cell
+    // around it no longer carries a `title` of its own for that answer to have to win over.
     await expect(cell.locator(CHIP)).toHaveAttribute(
       'title',
       `amount from the joined Data Mart \u201C${JOINED_TITLE}\u201D`
@@ -610,7 +611,7 @@ test.describe('Data Setup - Calculated field chips', () => {
     await page.goto(`/ui/0/data-marts/${dataMartId}/data-setup`);
     await expect(page.getByTestId(TESTIDS.datamartTabDataSetup)).toBeVisible();
 
-    const cell = page.locator(`[title="${JOINED_FORMULA}"]`).first();
+    const cell = findFormulaCell(page, JOINED_FORMULA);
     await expect(cell).toBeVisible({ timeout: 15000 });
 
     const surface = cell.locator('[data-slot="popover-trigger"]').first();
@@ -639,15 +640,17 @@ test.describe('Data Setup - Calculated field chips', () => {
     expect((formulaBox?.x ?? 0) + (formulaBox?.width ?? 0)).toBeLessThanOrEqual(aliasBox?.x ?? 0);
   });
 
-  test('wraps a long formula instead of cutting it off (DSET-10)', async ({ page }) => {
+  test('clamps a long formula to two lines instead of growing the row (DSET-10)', async ({
+    page,
+  }) => {
     test.setTimeout(90_000);
 
     await page.goto(`/ui/0/data-marts/${dataMartId}/data-setup`);
     await expect(page.getByTestId(TESTIDS.datamartTabDataSetup)).toBeVisible();
 
-    const shortCell = page.locator(`[title="${METRIC_FORMULA}"]`).first();
+    const shortCell = findFormulaCell(page, METRIC_FORMULA);
     await expect(shortCell).toBeVisible({ timeout: 15000 });
-    const longCell = page.locator(`[title="${LONG_FORMULA}"]`).first();
+    const longCell = findFormulaCell(page, LONG_FORMULA);
     await expect(longCell).toBeVisible({ timeout: 15000 });
 
     const longSurface = longCell.locator('[data-slot="popover-trigger"]').first();
@@ -656,27 +659,33 @@ test.describe('Data Setup - Calculated field chips', () => {
     const measured = await longSurface.evaluate(element => {
       const style = getComputedStyle(element);
       return {
-        textOverflow: style.textOverflow,
         whiteSpace: style.whiteSpace,
-        // With `truncate` the content is wider than the box and the tail is simply gone.
+        lineClamp: style.webkitLineClamp,
+        // Nothing is hidden sideways: the text wraps, so the formula never widens its column.
         clientWidth: element.clientWidth,
         scrollWidth: element.scrollWidth,
-        height: element.getBoundingClientRect().height,
       };
     });
-    const shortHeight = await shortSurface.evaluate(
-      element => element.getBoundingClientRect().height
-    );
 
-    expect(measured.textOverflow).not.toBe('ellipsis');
-    expect(measured.whiteSpace).toBe('pre-wrap');
-    // Nothing hidden sideways: every character is inside the box.
+    // The author's own line breaks fold into spaces, which is what lets a clamp count lines of
+    // rendered text rather than lines of source.
+    expect(measured.whiteSpace).toBe('normal');
+    expect(measured.lineClamp).toBe('2');
     expect(measured.scrollWidth).toBeLessThanOrEqual(measured.clientWidth + 1);
-    // …because it went onto more lines, which is the row growing rather than the text vanishing.
-    expect(measured.height).toBeGreaterThan(shortHeight);
 
-    // And the whole formula is there, chips included — a pill that straddles the line break is
-    // still one pill and still painted.
+    // The point of the clamp: a long formula costs the row nothing. Compared against a row whose
+    // formula fits on one line, because the row's height comes from the controls beside it.
+    const longRow = await longSurface.evaluate(
+      element => element.closest('tr')?.getBoundingClientRect().height ?? -1
+    );
+    const shortRow = await shortSurface.evaluate(
+      element => element.closest('tr')?.getBoundingClientRect().height ?? -1
+    );
+    expect(longRow).toBeGreaterThan(0);
+    expect(longRow).toBe(shortRow);
+
+    // The whole formula is still in the DOM, chips included — clipped for the eye, not truncated
+    // in the text — and it is what the hover card reads.
     expect((await longCell.textContent())?.trim()).toBe(LONG_FORMULA);
     const chips = longCell.locator(CHIP);
     await expect(chips).toHaveCount(4);
@@ -693,6 +702,25 @@ test.describe('Data Setup - Calculated field chips', () => {
       expect(pill.drawn).toBe(true);
       expect(pill.background).not.toBe('rgba(0, 0, 0, 0)');
     });
+  });
+
+  test('shows the whole formula in a hover card the clamped row cannot (DSET-10)', async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+
+    await page.goto(`/ui/0/data-marts/${dataMartId}/data-setup`);
+    await expect(page.getByTestId(TESTIDS.datamartTabDataSetup)).toBeVisible();
+
+    const longCell = findFormulaCell(page, LONG_FORMULA);
+    await expect(longCell).toBeVisible({ timeout: 15000 });
+
+    const card = page.locator('[data-slot="hover-card-content"]');
+    await expect(card).toHaveCount(0);
+
+    await longCell.hover();
+    await expect(card).toBeVisible({ timeout: 15000 });
+    expect((await card.textContent())?.trim()).toBe(LONG_FORMULA);
   });
 
   test('still opens the suggest list with the chip layer attached (DSET-10)', async ({ page }) => {

--- a/apps/web/e2e/specs/datamart-calculated-field-formula.spec.ts
+++ b/apps/web/e2e/specs/datamart-calculated-field-formula.spec.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 import { test, expect } from '../fixtures/base';
 import { TESTIDS } from '../selectors/testids';
+import { findFormulaCell } from '../helpers/formula-cell';
 
 // ---------------------------------------------------------------------------
 // DSET-09: the calculated-field formula editor's autocomplete.
@@ -90,7 +91,7 @@ test.describe('Data Setup - Calculated field formula autocomplete', () => {
     await expect(page.getByTestId(TESTIDS.datamartTabDataSetup)).toBeVisible();
 
     // The formula cell of the `roas` row — the whole cell carries the formula as its title.
-    const formulaCell = page.locator(`[title="${METRIC_FORMULA}"]`).first();
+    const formulaCell = findFormulaCell(page, METRIC_FORMULA);
     await expect(formulaCell).toBeVisible({ timeout: 15000 });
     await formulaCell.click();
 

--- a/apps/web/e2e/specs/datamart-calculated-field-formula.spec.ts
+++ b/apps/web/e2e/specs/datamart-calculated-field-formula.spec.ts
@@ -90,7 +90,6 @@ test.describe('Data Setup - Calculated field formula autocomplete', () => {
     await page.goto(`/ui/0/data-marts/${dataMartId}/data-setup`);
     await expect(page.getByTestId(TESTIDS.datamartTabDataSetup)).toBeVisible();
 
-    // The formula cell of the `roas` row — the whole cell carries the formula as its title.
     const formulaCell = findFormulaCell(page, METRIC_FORMULA);
     await expect(formulaCell).toBeVisible({ timeout: 15000 });
     await formulaCell.click();

--- a/apps/web/e2e/specs/datamart-row-level-calculated-field.spec.ts
+++ b/apps/web/e2e/specs/datamart-row-level-calculated-field.spec.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 import { test, expect } from '../fixtures/base';
 import { TESTIDS } from '../selectors/testids';
+import { findFormulaCell } from '../helpers/formula-cell';
 
 // ---------------------------------------------------------------------------
 // Authoring a ROW-LEVEL calculated field.
@@ -127,7 +128,7 @@ test.describe('Data Setup - row-level calculated field', () => {
     await expect(popover).toBeHidden();
 
     // The formula is on the row in AUTHORING form — the stored `{{ref}}` tag never reaches screen.
-    const formulaCell = page.locator(`[title="${ROW_LEVEL_FORMULA}"]`).first();
+    const formulaCell = findFormulaCell(page, ROW_LEVEL_FORMULA);
     await expect(formulaCell).toBeVisible();
     expect(await formulaCell.textContent()).toBe(ROW_LEVEL_FORMULA);
 
@@ -154,7 +155,7 @@ test.describe('Data Setup - row-level calculated field', () => {
     await page.reload();
     await expect(page.getByTestId(TESTIDS.datamartTabDataSetup)).toBeVisible();
 
-    const reloadedCell = page.locator(`[title="${ROW_LEVEL_FORMULA}"]`).first();
+    const reloadedCell = findFormulaCell(page, ROW_LEVEL_FORMULA);
     await expect(reloadedCell).toBeVisible({ timeout: 15000 });
     await expect(reloadedCell.locator(CHIP)).toHaveText('clicks');
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
@@ -20,6 +20,7 @@ import { useAiHelper, useAiHelperAvailability } from '../../model/hooks';
 import type { ResolvedSchema } from '../../model/hooks';
 import type { SchemaToolbar } from './types/schema-toolbar';
 import {
+  rejectedFormulaMessage,
   useCalculatedFieldSave,
   type ViolationsByField,
 } from './calculated/useCalculatedFieldSave';
@@ -371,7 +372,14 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
   const guardSave = useCallback(async (): Promise<ResolvedSchema> => {
     const current = schemaRef.current;
     if (dataMartId && current) {
-      await saveCalculatedFields(current);
+      try {
+        await saveCalculatedFields(current);
+      } catch (error) {
+        // The dialog can only render a string, and an axios rejection's own `message` is
+        // "Request failed with status code 400" — which names neither the field nor the fix. The
+        // field-grouped detail is already on screen behind the dialog; point at it.
+        throw new Error(rejectedFormulaMessage(error) ?? 'Failed to save changes');
+      }
       markSchemaSaved(current);
       invalidateBlendableSchema();
     }

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@owox/ui/components/button';
+import { extractApiError } from '../../../../../app/api';
 import { TriangleAlert } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import toast from 'react-hot-toast';
@@ -378,7 +379,11 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
         // The dialog can only render a string, and an axios rejection's own `message` is
         // "Request failed with status code 400" — which names neither the field nor the fix. The
         // field-grouped detail is already on screen behind the dialog; point at it.
-        throw new Error(rejectedFormulaMessage(error) ?? 'Failed to save changes');
+        throw new Error(
+          rejectedFormulaMessage(error) ??
+            extractApiError(error).message ??
+            'Failed to save changes'
+        );
       }
       markSchemaSaved(current);
       invalidateBlendableSchema();

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/CalculatedFieldFormulaCell.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/CalculatedFieldFormulaCell.test.tsx
@@ -134,12 +134,12 @@ function renderCell({
   live = false,
   fieldName,
 }: CellOptions = {}) {
-  render(
+  const cell = (withFormula: string) => (
     // The provider the schema page puts above every table: the live check has to be told what the
     // editor is HOLDING, or it resolves a sibling reference against the schema on disk.
     <DraftCalculatedFieldsContext.Provider value={collectDraftCalculatedFields(own)}>
       <CalculatedFieldFormulaCell
-        formula={formula}
+        formula={withFormula}
         index={[...buildReferenceIndex(own), ...buildJoinedReferenceIndex(joined)]}
         functionNames={aggregateFunctionsFor(DataStorageType.GOOGLE_BIGQUERY)}
         joinedFieldsStatus={joinedFieldsStatus}
@@ -150,21 +150,43 @@ function renderCell({
       />
     </DraftCalculatedFieldsContext.Provider>
   );
+  const view = render(cell(formula));
+  // The cell is controlled: a test that needs the SAVED formula back on screen re-renders with it,
+  // the way the schema page does after `onSave`.
+  saveAndReRender = next => {
+    view.rerender(cell(next));
+  };
   return onSave;
 }
+
+/** Set by the most recent `renderCell`. */
+let saveAndReRender: (formula: string) => void = () => {
+  throw new Error('renderCell has not run yet');
+};
 
 /**
  * The row showing `text`. Found by its title rather than its text because a resolved reference is
  * its own `<span>` chip now, so the formula is several text nodes and `getByText` matches none.
  */
+/**
+ * The row's formula cell, and an assertion that it shows `text`.
+ *
+ * Located by slot rather than by text — a resolved reference is its own `<span>` chip, so the
+ * formula is several text nodes and `getByText` matches none — but the text is still checked,
+ * which is what `getByTitle` used to do implicitly at every call site. One cell per render, so
+ * the first trigger is this cell's. Pass `''` for a row whose formula is not set yet: it shows a
+ * placeholder instead.
+ */
 function formulaRow(text: string): HTMLElement {
-  // Found by slot rather than by text: a resolved reference is its own `<span>` chip, so the
-  // formula is several text nodes and `getByText` matches none. One cell per render, so the
-  // first trigger IS this cell's. An empty formula shows the placeholder and gets no hover card.
-  const trigger =
-    document.querySelector<HTMLElement>('[data-slot="popover-trigger"]') ??
-    document.querySelector<HTMLElement>('[data-slot="hover-card-trigger"]');
-  return trigger ?? screen.getByText(text);
+  const cell = document.querySelector<HTMLElement>('[data-slot="hover-card-trigger"]');
+  if (!cell) throw new Error('no formula cell rendered');
+  const shown = cell.textContent;
+  if (text !== '' && shown !== text) {
+    throw new Error(
+      `formula cell shows ${JSON.stringify(shown)}, expected ${JSON.stringify(text)}`
+    );
+  }
+  return cell.querySelector<HTMLElement>('[data-slot="popover-trigger"]') ?? cell;
 }
 
 /** The hover card's own copy of the formula, or null while it is closed. */
@@ -173,7 +195,7 @@ function hoverCard(): HTMLElement | null {
 }
 
 function hoverRow() {
-  const trigger = document.querySelector<HTMLElement>('[data-slot="hover-card-trigger"]');
+  const trigger = formulaRow('').closest('[data-slot="hover-card-trigger"]');
   if (!trigger) throw new Error('no hover-card trigger on the row');
   fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
   act(() => {
@@ -865,9 +887,31 @@ describe('the row preview', () => {
     expect(preview?.textContent).toBe('SAFE_DIVIDE(\n  SUM(clicks),\n  SUM(impressions)\n)');
   });
 
-  it('offers no card for a formula that is not there yet', () => {
+  // The wrapper stays mounted for an empty formula — swapping it in and out on the first Apply
+  // replaced the subtree and cost the cell the editor's own close report — but it has nothing to
+  // show and never opens.
+  it('opens no card for a formula that is not there yet', () => {
     renderCell({ formula: '' });
 
-    expect(document.querySelector('[data-slot="hover-card-trigger"]')).toBeNull();
+    expect(document.querySelector('[data-slot="hover-card-trigger"]')).not.toBeNull();
+    hoverRow();
+    expect(hoverCard()).toBeNull();
+  });
+
+  // Applying the first formula of a NEW field used to swap `children` for the card wrapper in the
+  // same commit that closed the editor: React unmounted `EditableText` before its close could be
+  // reported, `isEditing` stuck at true, and the row's card never opened again.
+  it('still opens after the first formula is applied to a new field', () => {
+    const renderCellResult = renderCell({ formula: '' });
+
+    const onSave = renderCellResult;
+    fireEvent.click(formulaRow(''));
+    typeFormula('SUM(clicks)');
+    apply();
+    expect(onSave).toHaveBeenCalledWith('SUM({{ref field="clicks"}})');
+    saveAndReRender('SUM({{ref field="clicks"}})');
+
+    hoverRow();
+    expect(hoverCard()?.textContent).toBe('SUM(clicks)');
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/CalculatedFieldFormulaCell.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/CalculatedFieldFormulaCell.test.tsx
@@ -158,9 +158,27 @@ function renderCell({
  * its own `<span>` chip now, so the formula is several text nodes and `getByText` matches none.
  */
 function formulaRow(text: string): HTMLElement {
-  // An empty formula shows the placeholder instead, which is one text node and carries no title.
-  const row = screen.queryByTitle(text) ?? screen.getByText(text);
-  return row.querySelector<HTMLElement>('[data-slot="popover-trigger"]') ?? row;
+  // Found by slot rather than by text: a resolved reference is its own `<span>` chip, so the
+  // formula is several text nodes and `getByText` matches none. One cell per render, so the
+  // first trigger IS this cell's. An empty formula shows the placeholder and gets no hover card.
+  const trigger =
+    document.querySelector<HTMLElement>('[data-slot="popover-trigger"]') ??
+    document.querySelector<HTMLElement>('[data-slot="hover-card-trigger"]');
+  return trigger ?? screen.getByText(text);
+}
+
+/** The hover card's own copy of the formula, or null while it is closed. */
+function hoverCard(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[data-slot="hover-card-content"]');
+}
+
+function hoverRow() {
+  const trigger = document.querySelector<HTMLElement>('[data-slot="hover-card-trigger"]');
+  if (!trigger) throw new Error('no hover-card trigger on the row');
+  fireEvent.pointerEnter(trigger, { pointerType: 'mouse' });
+  act(() => {
+    vi.advanceTimersByTime(400);
+  });
 }
 
 function openEditor(triggerText: string) {
@@ -505,8 +523,6 @@ describe('CalculatedFieldFormulaCell', () => {
       );
 
       expect(titles).toEqual([null, 'amount from the joined Data Mart \u201COrders\u201D']);
-      // The whole formula stays on the cell, so a hover anywhere else still shows it.
-      expect(screen.getByTitle('SUM(clicks) + SUM(orders.amount)')).toBeInTheDocument();
     });
   });
 
@@ -793,5 +809,65 @@ describe('CalculatedFieldFormulaCell', () => {
       expect(onSave).not.toHaveBeenCalled();
       expect(screen.getByRole('alert')).toHaveTextContent('orders.secret');
     });
+  });
+});
+
+describe('the row preview', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const MULTILINE =
+    'SAFE_DIVIDE(\n  SUM({{ref field="clicks"}}),\n  SUM({{ref field="impressions"}})\n)';
+
+  it('holds the row to two lines however many the formula was authored over', () => {
+    renderCell({ formula: MULTILINE });
+
+    // The fold is CSS, which happy-dom lays out nowhere, so the classes ARE the assertion — they
+    // are also the whole mechanism: nothing rewrites the formula's text, which still holds its
+    // newlines and is what the hover card and the editor read.
+    const preview = formulaRow('');
+    expect(preview.className).toContain('line-clamp-2');
+    expect(preview.className).toContain('whitespace-normal');
+    expect(preview.textContent).toContain('\n');
+  });
+
+  it('shows the whole formula on hover, line breaks and all', () => {
+    renderCell({ formula: MULTILINE });
+    expect(hoverCard()).toBeNull();
+
+    hoverRow();
+
+    expect(hoverCard()?.textContent).toBe('SAFE_DIVIDE(\n  SUM(clicks),\n  SUM(impressions)\n)');
+  });
+
+  it('stands down while the editor is open, so one row never carries two popovers', () => {
+    renderCell({ formula: MULTILINE });
+    hoverRow();
+    expect(hoverCard()).not.toBeNull();
+
+    openEditor('');
+
+    expect(screen.getByTestId('formula-editor')).toBeInTheDocument();
+    expect(hoverCard()).toBeNull();
+  });
+
+  it('lets a keyboard reach a read-only formula, which has no editor to focus instead', () => {
+    renderCell({ formula: MULTILINE, readOnly: true });
+
+    const preview = document.querySelector<HTMLElement>('[data-slot="hover-card-trigger"]');
+    expect(preview?.tabIndex).toBe(0);
+    // The clamp hides nothing from a screen reader: the whole formula is still text in the DOM.
+    expect(preview?.textContent).toBe('SAFE_DIVIDE(\n  SUM(clicks),\n  SUM(impressions)\n)');
+  });
+
+  it('offers no card for a formula that is not there yet', () => {
+    renderCell({ formula: '' });
+
+    expect(document.querySelector('[data-slot="hover-card-trigger"]')).toBeNull();
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/CalculatedFieldFormulaCell.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/CalculatedFieldFormulaCell.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
 import { EditableText } from '@owox/ui/components/common/editable-text';
 import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@owox/ui/components/hover-card';
@@ -106,7 +106,7 @@ function LiveCheckedFormulaEditor({
 }
 
 /**
- * Plain text on the row's own background, ONE line, truncated.
+ * Plain text on the row's own background, clamped to two lines.
  *
  * NOT on a surface of its own: a filled one was tried and rejected. It began under the `Mode`
  * header and ran under `PK` and the aggregations, so a solid rectangle sat beneath three headers
@@ -142,31 +142,62 @@ const CARD_CLASSES = 'font-mono text-xs break-words whitespace-pre-wrap text-for
  *
  * Suppressed while the editor is open: the editor's popover is anchored to this same cell, and two
  * floating layers over one row is one too many. `open` is therefore controlled rather than left to
- * the primitive, which has no way to know about the other popover.
+ * the primitive, which has no way to know about the other popover — and lowered explicitly on the
+ * way in, because Radix drops a close whose value already matches the prop, which would leave a
+ * stale `open` to spring back the moment suppression lifts.
  *
- * Opens on focus as well as hover, so the formula a clamped row hides is still reachable from the
- * keyboard — which is why both triggers take focus: the editable one through `EditableText`'s own
- * `role='button'`, the read-only one through a `tabIndex` of its own. Nothing is rendered for an
- * empty formula — the row shows its placeholder and there is no second telling of it.
+ * `openOnFocus` belongs to the READ-ONLY row, which has no editor to open and would otherwise be
+ * unreachable without a pointer. The editable row refuses it: the editor's popover returns focus
+ * to this very trigger when it closes, and Radix opens on ANY focus, so every Apply would be
+ * followed by a card appearing over the rows below with nothing to explain it. A keyboard reader
+ * there opens the editor itself, which shows more than the card does.
+ *
+ * The wrapper renders even for an empty formula — with nothing to show and nothing to open. It
+ * used to return `children` bare, and applying the FIRST formula of a new field then swapped one
+ * element type for another at the same position: React unmounted the editor before its close could
+ * be reported, and the cell stayed suppressed for good.
  */
 function FormulaHoverCard({
   text,
   references,
   describeReference,
   suppressed,
+  openOnFocus,
   children,
 }: {
   text: string;
   references: readonly ResolvedReference[];
   describeReference: (reference: ResolvedReference) => string | undefined;
   suppressed: boolean;
+  openOnFocus: boolean;
   children: ReactElement;
 }) {
   const [open, setOpen] = useState(false);
-  if (text.trim() === '') return children;
+  useEffect(() => {
+    if (suppressed) setOpen(false);
+  }, [suppressed]);
+  const empty = text.trim() === '';
   return (
-    <HoverCard open={open && !suppressed} onOpenChange={setOpen} openDelay={300} closeDelay={100}>
-      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+    <HoverCard
+      open={open && !suppressed && !empty}
+      onOpenChange={setOpen}
+      openDelay={300}
+      closeDelay={100}
+    >
+      <HoverCardTrigger
+        asChild
+        // Radix composes this with its own opener and skips that opener once the event is
+        // defaulted-prevented, which is the whole mechanism behind `openOnFocus`.
+        onFocus={
+          openOnFocus
+            ? undefined
+            : event => {
+                event.preventDefault();
+              }
+        }
+      >
+        {children}
+      </HoverCardTrigger>
       {/* Matches the editor popover's own width, so hovering and editing show the formula
           wrapped at the same measure. */}
       <HoverCardContent align='start' className='px-4 py-3 sm:w-[520px] sm:max-w-[520px]'>
@@ -231,6 +262,7 @@ export function CalculatedFieldFormulaCell({
         references={authoring.refs}
         describeReference={describeReference}
         suppressed={false}
+        openOnFocus
       >
         {/* Focusable so the card is reachable without a pointer: this read-only row has no editor
             behind it, so nothing else here takes focus. The clamp is visual only — the whole
@@ -270,6 +302,7 @@ export function CalculatedFieldFormulaCell({
       references={authoring.refs}
       describeReference={describeReference}
       suppressed={isEditing}
+      openOnFocus={false}
     >
       <div>
         <EditableText

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/CalculatedFieldFormulaCell.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/CalculatedFieldFormulaCell.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 import { EditableText } from '@owox/ui/components/common/editable-text';
 import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@owox/ui/components/hover-card';
 import { useDraftCalculatedFields } from './draft-calculated-fields';
 import { toAuthoringForm, toStoredForm, type ResolvedReference } from './formula-authoring';
 import { FormulaChips } from './FormulaChips';
@@ -105,7 +106,7 @@ function LiveCheckedFormulaEditor({
 }
 
 /**
- * Plain text on the row's own background, wrapping rather than truncating.
+ * Plain text on the row's own background, ONE line, truncated.
  *
  * NOT on a surface of its own: a filled one was tried and rejected. It began under the `Mode`
  * header and ran under `PK` and the aggregations, so a solid rectangle sat beneath three headers
@@ -113,12 +114,69 @@ function LiveCheckedFormulaEditor({
  * is said by a rule at the band's edge instead (`SchemaTable.tsx`), which is a mark a table already
  * means as a column boundary.
  *
- * `whitespace-pre-wrap` overrides the `white-space: pre` the table cell sets inline — without it a
- * long formula is one unbroken line and the wrap never happens. `break-words` covers the case that
- * has no space to break at: one very long identifier.
+ * It used to wrap, and a formula authored over several lines made its row several lines tall — a
+ * calculated field pushed the whole table around in a way no ordinary field does.
+ *
+ * `whitespace-normal` overrides the `white-space: pre` the cell sets inline, folding the author's
+ * own newlines and indentation into single spaces; `line-clamp-2` then keeps two lines of the
+ * result. Nothing here rewrites the text, so the reference spans still line up with it, and the
+ * whole formula is a hover away.
+ *
+ * TWO lines because they are free: the row's height comes from the controls beside the formula,
+ * measured at 49px whether the formula occupies one 16px line or two. The third line is what
+ * costs — it takes the row to 64px.
+ *
+ * Clamped rather than `whitespace-nowrap`, which also bounds the height but makes the formula
+ * unbreakable: measured on this table's own widths, that grew the formula column from 549px to
+ * 1042px at the other columns' expense. Wrapped text keeps the intrinsic width it always had.
  */
 const PREVIEW_CLASSES =
-  'max-w-full font-mono text-xs break-words whitespace-pre-wrap text-gray-600 dark:text-gray-300';
+  'line-clamp-2 max-w-full font-mono text-xs break-words whitespace-normal ' +
+  'text-gray-600 dark:text-gray-300';
+
+/** The same formula in the hover card, where the author's own line breaks are worth keeping. */
+const CARD_CLASSES = 'font-mono text-xs break-words whitespace-pre-wrap text-foreground';
+
+/**
+ * The whole formula, for a row that now shows only its first line.
+ *
+ * Suppressed while the editor is open: the editor's popover is anchored to this same cell, and two
+ * floating layers over one row is one too many. `open` is therefore controlled rather than left to
+ * the primitive, which has no way to know about the other popover.
+ *
+ * Opens on focus as well as hover, so the formula a clamped row hides is still reachable from the
+ * keyboard — which is why both triggers take focus: the editable one through `EditableText`'s own
+ * `role='button'`, the read-only one through a `tabIndex` of its own. Nothing is rendered for an
+ * empty formula — the row shows its placeholder and there is no second telling of it.
+ */
+function FormulaHoverCard({
+  text,
+  references,
+  describeReference,
+  suppressed,
+  children,
+}: {
+  text: string;
+  references: readonly ResolvedReference[];
+  describeReference: (reference: ResolvedReference) => string | undefined;
+  suppressed: boolean;
+  children: ReactElement;
+}) {
+  const [open, setOpen] = useState(false);
+  if (text.trim() === '') return children;
+  return (
+    <HoverCard open={open && !suppressed} onOpenChange={setOpen} openDelay={300} closeDelay={100}>
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      {/* Matches the editor popover's own width, so hovering and editing show the formula
+          wrapped at the same measure. */}
+      <HoverCardContent align='start' className='px-4 py-3 sm:w-[520px] sm:max-w-[520px]'>
+        <div className={CARD_CLASSES}>
+          <FormulaChips text={text} references={references} describeReference={describeReference} />
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
 
 const CALCULATED_FIELDS_DOCS =
   'https://docs.owox.com/docs/getting-started/setup-guide/calculated-fields/' +
@@ -163,16 +221,28 @@ export function CalculatedFieldFormulaCell({
    */
   const [draftRefs, setDraftRefs] = useState<ResolvedReference[] | null>(null);
   const refs = draftRefs ?? authoring.refs;
+  /** Whether the editor popover is open, so the hover card can stand down while it is. */
+  const [isEditing, setIsEditing] = useState(false);
 
   if (!onSave) {
     return (
-      <span className={`block w-full ${PREVIEW_CLASSES}`} title={authoring.text}>
-        <FormulaChips
-          text={authoring.text}
-          references={authoring.refs}
-          describeReference={describeReference}
-        />
-      </span>
+      <FormulaHoverCard
+        text={authoring.text}
+        references={authoring.refs}
+        describeReference={describeReference}
+        suppressed={false}
+      >
+        {/* Focusable so the card is reachable without a pointer: this read-only row has no editor
+            behind it, so nothing else here takes focus. The clamp is visual only — the whole
+            formula is in the DOM either way, which is what a screen reader reads. */}
+        <span tabIndex={0} className={`w-full ${PREVIEW_CLASSES}`}>
+          <FormulaChips
+            text={authoring.text}
+            references={authoring.refs}
+            describeReference={describeReference}
+          />
+        </span>
+      </FormulaHoverCard>
     );
   }
 
@@ -195,56 +265,67 @@ export function CalculatedFieldFormulaCell({
   };
 
   return (
-    <div title={authoring.text}>
-      <EditableText
-        value={authoring.text}
-        placeholder='Formula is required'
-        className={PREVIEW_CLASSES}
-        // The name of the row being edited, which the open popover covers up. Not "Formula" when a
-        // name is known — the hint below already says what this editor is.
-        editorTitle={fieldName?.trim() ? fieldName : 'Formula'}
-        editorHint={
-          <>
-            Warehouse SQL over this Data Mart&apos;s fields.{' '}
-            <ExternalAnchor href={CALCULATED_FIELDS_DOCS}>Learn more</ExternalAnchor>
-          </>
-        }
-        // The row shows the PERSISTED formula, so it draws the stored tags' own spans — never
-        // `refs`, which follow the popover's draft and would not line up with this text.
-        renderValue={text => (
-          <FormulaChips
-            text={text}
-            references={authoring.refs}
-            describeReference={describeReference}
-          />
-        )}
-        onEditStart={() => {
-          setDraftRefs(null);
-        }}
-        onApply={applyFormula}
-        renderEditor={ctx => (
-          <div className='w-[520px]'>
-            <LiveCheckedFormulaEditor
-              value={ctx.value}
-              references={refs}
-              index={index}
-              functionNames={functionNames}
-              scalarFunctionNames={scalarFunctionNames}
-              ariaLabel='Formula'
-              dataMartId={dataMartId}
-              fieldName={fieldName}
-              fieldType={fieldType}
-              onChange={next => {
-                setDraftRefs(next.refs);
-                ctx.setValue(next.text);
-              }}
-              // `EditableText` binds Enter and Ctrl+Enter to the textarea this editor replaces, so
-              // on this path they reach nothing. Same action as the Apply button, refusal included.
-              onSubmit={ctx.apply}
+    <FormulaHoverCard
+      text={authoring.text}
+      references={authoring.refs}
+      describeReference={describeReference}
+      suppressed={isEditing}
+    >
+      <div>
+        <EditableText
+          value={authoring.text}
+          placeholder='Formula is required'
+          className={PREVIEW_CLASSES}
+          // The name of the row being edited, which the open popover covers up. Not "Formula" when a
+          // name is known — the hint below already says what this editor is.
+          editorTitle={fieldName?.trim() ? fieldName : 'Formula'}
+          editorHint={
+            <>
+              Warehouse SQL over this Data Mart&apos;s fields.{' '}
+              <ExternalAnchor href={CALCULATED_FIELDS_DOCS}>Learn more</ExternalAnchor>
+            </>
+          }
+          // The row shows the PERSISTED formula, so it draws the stored tags' own spans — never
+          // `refs`, which follow the popover's draft and would not line up with this text.
+          renderValue={text => (
+            <FormulaChips
+              text={text}
+              references={authoring.refs}
+              describeReference={describeReference}
             />
-          </div>
-        )}
-      />
-    </div>
+          )}
+          onEditStart={() => {
+            setIsEditing(true);
+            setDraftRefs(null);
+          }}
+          onEditEnd={() => {
+            setIsEditing(false);
+          }}
+          onApply={applyFormula}
+          renderEditor={ctx => (
+            <div className='w-[520px]'>
+              <LiveCheckedFormulaEditor
+                value={ctx.value}
+                references={refs}
+                index={index}
+                functionNames={functionNames}
+                scalarFunctionNames={scalarFunctionNames}
+                ariaLabel='Formula'
+                dataMartId={dataMartId}
+                fieldName={fieldName}
+                fieldType={fieldType}
+                onChange={next => {
+                  setDraftRefs(next.refs);
+                  ctx.setValue(next.text);
+                }}
+                // `EditableText` binds Enter and Ctrl+Enter to the textarea this editor replaces, so
+                // on this path they reach nothing. Same action as the Apply button, refusal included.
+                onSubmit={ctx.apply}
+              />
+            </div>
+          )}
+        />
+      </div>
+    </FormulaHoverCard>
   );
 }

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/formula-violation-ranges.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/formula-violation-ranges.test.ts
@@ -42,10 +42,21 @@ const VIOLATIONS = {
       'A formula is a single expression and cannot contain `;`. Remove the semicolon — a formula ' +
       'never ends a statement.',
   },
+  // Two shapes, because the backend names the denominator only when a span of the formula stands
+  // for the WHOLE of it — quoting a fragment would send the analyst to guard the wrong thing.
   unguardedDivision: {
+    subject: 'SUM(impressions)',
     message:
-      'This formula divides without guarding against a zero or empty denominator. Wrap it, e.g. ' +
-      'NULLIF(SUM(impressions), 0).',
+      '`SUM(impressions)` can come out ZERO, and dividing by zero fails the whole report at the ' +
+      'warehouse rather than leaving one cell blank. Wrap it as NULLIF(SUM(impressions), 0), ' +
+      'which turns the zero into an empty cell. Advice only: this does not block the save.',
+  },
+  unguardedDivisionUnnamed: {
+    message:
+      'This formula divides by something that can come out ZERO, and dividing by zero fails the ' +
+      'whole report at the warehouse rather than leaving one cell blank. Wrap the denominator as ' +
+      'NULLIF(it, 0), which turns the zero into an empty cell. Advice only: this does not block ' +
+      'the save.',
   },
   subquery: { message: 'A formula cannot contain a subquery.' },
 } satisfies Record<string, PlaceableViolation>;
@@ -70,8 +81,14 @@ describe('violationSubject — the fallback for a violation carrying no subject'
   });
 
   it('has none for a message about the whole formula', () => {
-    expect(violationSubject(VIOLATIONS.unguardedDivision.message)).toBeNull();
+    expect(violationSubject(VIOLATIONS.unguardedDivisionUnnamed.message)).toBeNull();
     expect(violationSubject(VIOLATIONS.subquery.message)).toBeNull();
+  });
+
+  // The other half of that pair: when the backend DOES name the denominator it leads with it, so
+  // the fallback reads the same token the structured `subject` carries.
+  it('reads the denominator a division warning names', () => {
+    expect(violationSubject(VIOLATIONS.unguardedDivision.message)).toBe('SUM(impressions)');
   });
 });
 
@@ -138,8 +155,16 @@ describe('violationRanges', () => {
 
   it('places nothing for a violation that names no token', () => {
     expect(
-      violationRanges(VIOLATIONS.unguardedDivision, 'SUM(clicks) / SUM(impressions)', [])
+      violationRanges(VIOLATIONS.unguardedDivisionUnnamed, 'SUM(clicks) / SUM(impressions)', [])
     ).toEqual([]);
+  });
+
+  // …and marks the denominator when the violation does name one, which is the whole reason it
+  // carries a subject rather than leaving the reader to find the division themselves.
+  it('marks the denominator a division warning names', () => {
+    expect(
+      violationRanges(VIOLATIONS.unguardedDivision, 'SUM(clicks) / SUM(impressions)', [])
+    ).toEqual([{ start: 14, end: 30 }]);
   });
 
   it('ignores a reference whose span no longer holds its own text', () => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/useCalculatedFieldSave.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/useCalculatedFieldSave.test.ts
@@ -1,7 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import type { DataMartSchema } from '../../../../shared/types/data-mart-schema.types';
-import { useCalculatedFieldSave, type CalculatedFieldSaveOutcome } from './useCalculatedFieldSave';
+import {
+  rejectedFormulaMessage,
+  useCalculatedFieldSave,
+  type CalculatedFieldSaveOutcome,
+} from './useCalculatedFieldSave';
 
 vi.mock('../../../../../../shared/utils', () => ({
   showApiErrorToast: vi.fn(),
@@ -395,5 +399,27 @@ describe('useCalculatedFieldSave', () => {
 
     expect(result.current.warningsByField).toEqual({});
     expect(result.current.errorsByField).toEqual({});
+  });
+});
+
+describe('rejectedFormulaMessage', () => {
+  it('names every rejected field so the unsaved-changes dialog can say more than the status code', () => {
+    const message = rejectedFormulaMessage(
+      apiError(400, {
+        errorDetails: {
+          errors: [
+            { code: 'FORMULA_DRY_RUN_FAILED', field: 'activation_rate', message: 'Rejected.' },
+            { code: 'FORMULA_UNKNOWN_REFERENCE', field: 'roas', message: 'Gone.' },
+          ],
+        },
+      })
+    );
+
+    expect(message).toContain('activation_rate');
+    expect(message).toContain('roas');
+  });
+
+  it('declines an unrelated failure so the caller keeps its own wording', () => {
+    expect(rejectedFormulaMessage(apiError(500))).toBeUndefined();
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/useCalculatedFieldSave.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/useCalculatedFieldSave.ts
@@ -58,6 +58,19 @@ function groupByField(violations: ApiFormulaViolation[] | undefined): Violations
 }
 
 /**
+ * The one-line summary of a rejected save, for a surface that can only render a string — today the
+ * unsaved-changes dialog, which otherwise shows axios's own "Request failed with status code 400".
+ * Returns undefined when the rejection carries no formula violations, so the caller keeps its own
+ * wording for an unrelated failure.
+ */
+export function rejectedFormulaMessage(error: unknown): string | undefined {
+  const violations = extractApiError(error).errorDetails?.errors;
+  const fields = Object.keys(groupByField(violations));
+  if (fields.length === 0) return undefined;
+  return `The warehouse rejected ${fields.join(', ')}. Close this dialog to see why.`;
+}
+
+/**
  * Mirrors `apiClient.ts`'s response interceptor for 403/404/5xx. `save` always sets
  * `skipErrorToast` on its underlying request (this hook renders its own field-grouped feedback
  * for the 400 case instead), so a failure that ISN'T a calculated-field violation gets NO toast

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/useCalculatedFieldSave.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/calculated/useCalculatedFieldSave.ts
@@ -67,7 +67,9 @@ export function rejectedFormulaMessage(error: unknown): string | undefined {
   const violations = extractApiError(error).errorDetails?.errors;
   const fields = Object.keys(groupByField(violations));
   if (fields.length === 0) return undefined;
-  return `The warehouse rejected ${fields.join(', ')}. Close this dialog to see why.`;
+  // Not "the warehouse rejected": the same list carries refusals the parser made before any
+  // warehouse was asked, and a storage that is not configured yet is never asked at all.
+  return `The save was rejected for ${fields.join(', ')}. Close this dialog to see why.`;
 }
 
 /**

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.test.tsx
@@ -35,4 +35,70 @@ describe('useSchemaState', () => {
     });
     expect(result.current.isDirty).toBe(true);
   });
+
+  it('keeps unsaved edits when a background refetch republishes the same saved schema', () => {
+    const { result, rerender } = renderHook(
+      ({ initial }: { initial: DataMartSchema }) => useSchemaState(initial),
+      { initialProps: { initial: initialSchema } }
+    );
+
+    act(() => {
+      result.current.updateSchema([
+        ...initialSchema.fields,
+        {
+          name: 'activation_rate',
+          type: 'FLOAT',
+          mode: 'NULLABLE',
+          calculated: { formula: 'SAFE_DIVIDE(SUM(a), SUM(b))' },
+        },
+      ] as typeof initialSchema.fields);
+    });
+    expect(result.current.schema?.fields).toHaveLength(2);
+
+    // Nothing was saved: this is the SAME persisted schema arriving as a fresh object, which is
+    // what any background refetch of the Data Mart produces.
+    rerender({
+      initial: { ...initialSchema, fields: [...initialSchema.fields] } as DataMartSchema,
+    });
+
+    expect(result.current.schema?.fields).toHaveLength(2);
+    expect(result.current.isDirty).toBe(true);
+  });
+
+  // `markSchemaSaved` puts the CLIENT's copy on screen — the level belongs to the save, which
+  // derives it. Content comparison must therefore not treat the server's answer as already
+  // applied, or the derived level never lands and the row keeps a shape the save disagreed with.
+  it('still accepts the server copy of a schema it was told to keep', () => {
+    const clientSchema = {
+      ...initialSchema,
+      fields: [{ name: 'ctr', type: 'FLOAT', mode: 'NULLABLE', calculated: { formula: 'SUM(a)' } }],
+    } as DataMartSchema;
+    const serverSchema = {
+      ...initialSchema,
+      fields: [
+        {
+          name: 'ctr',
+          type: 'FLOAT',
+          mode: 'NULLABLE',
+          calculated: { formula: 'SUM(a)', level: 'metric' },
+        },
+      ],
+    } as DataMartSchema;
+
+    const { result, rerender } = renderHook(
+      ({ initial }: { initial: DataMartSchema }) => useSchemaState(initial),
+      { initialProps: { initial: initialSchema } }
+    );
+
+    act(() => {
+      result.current.markSchemaSaved(clientSchema);
+    });
+    // The publish this save produces is skipped, as the guarded follow-up action needs.
+    rerender({ initial: serverSchema });
+    expect(result.current.schema?.fields[0]).not.toHaveProperty('calculated.level');
+
+    // The one after it is not: the server's copy differs from what is on screen, so it lands.
+    rerender({ initial: { ...serverSchema, fields: [...serverSchema.fields] } as DataMartSchema });
+    expect(result.current.schema?.fields[0]).toMatchObject({ calculated: { level: 'metric' } });
+  });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.ts
@@ -44,11 +44,15 @@ function fingerprint(schema: DataMartSchema | null | undefined): string {
  * @returns An object containing the schema state and functions to update it
  */
 export function useSchemaState(initialSchema: DataMartSchema | null | undefined) {
-  const clonedInitialSchema = deepCloneSchema(initialSchema);
-  const [schema, setSchema] = useState<DataMartSchema | null | undefined>(clonedInitialSchema);
+  const [schema, setSchema] = useState<DataMartSchema | null | undefined>(() =>
+    deepCloneSchema(initialSchema)
+  );
   const [isDirty, setIsDirty] = useState(false);
   const skipNextInitialSchemaResetRef = useRef(false);
-  const appliedInitialSchemaRef = useRef(fingerprint(clonedInitialSchema));
+  // Filled on first use rather than passed to `useRef`, whose argument is evaluated on EVERY render
+  // and thrown away after the first — and this one serialises the whole schema.
+  const appliedInitialSchemaRef = useRef<string | null>(null);
+  appliedInitialSchemaRef.current ??= fingerprint(initialSchema);
 
   // Reset schema when initialSchema changes
   useEffect(() => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.ts
@@ -32,6 +32,10 @@ function deepCloneSchema<T extends DataMartSchema | null | undefined>(schema: T)
   return JSON.parse(JSON.stringify(schema)) as T;
 }
 
+function fingerprint(schema: DataMartSchema | null | undefined): string {
+  return JSON.stringify(schema ?? null);
+}
+
 /**
  * Custom hook for managing schema state.
  * Extracts state management logic from the DataMartSchemaSettings component.
@@ -44,13 +48,24 @@ export function useSchemaState(initialSchema: DataMartSchema | null | undefined)
   const [schema, setSchema] = useState<DataMartSchema | null | undefined>(clonedInitialSchema);
   const [isDirty, setIsDirty] = useState(false);
   const skipNextInitialSchemaResetRef = useRef(false);
+  const appliedInitialSchemaRef = useRef(fingerprint(clonedInitialSchema));
 
   // Reset schema when initialSchema changes
   useEffect(() => {
     if (skipNextInitialSchemaResetRef.current) {
       skipNextInitialSchemaResetRef.current = false;
+      // Deliberately NOT recorded as applied: what is on screen is the schema this hook was told
+      // to keep, not the one just skipped. Recording the skipped one would make it match every
+      // later republish, and the server's own version — the level it derived — would never land.
       return;
     }
+    const incoming = fingerprint(initialSchema);
+    // Compared by CONTENT, not identity. Every refetch of the Data Mart hands this hook a fresh
+    // object — the runs poll, an actualization, a relationship change — and resetting on identity
+    // alone silently discards whatever the analyst has typed since, while a failed save's errors
+    // stay on screen naming a field that is no longer in the table.
+    if (incoming === appliedInitialSchemaRef.current) return;
+    appliedInitialSchemaRef.current = incoming;
     const clonedSchema = deepCloneSchema(initialSchema);
     setSchema(clonedSchema);
     setIsDirty(false);
@@ -63,6 +78,9 @@ export function useSchemaState(initialSchema: DataMartSchema | null | undefined)
    */
   const markSchemaSaved = useCallback((savedSchema: DataMartSchema) => {
     skipNextInitialSchemaResetRef.current = true;
+    // What is on screen from here on, so the next initialSchema that DIFFERS from it still resets
+    // — including the server's own copy of this save, which carries the level it derived.
+    appliedInitialSchemaRef.current = fingerprint(savedSchema);
     setSchema(deepCloneSchema(savedSchema));
     setIsDirty(false);
   }, []);

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.test.tsx
@@ -209,11 +209,22 @@ function buildAthenaField(overrides: Partial<AthenaSchemaField> = {}): AthenaSch
 }
 
 /**
- * The formula cell's clickable trigger. Found by title rather than by text: a resolved reference
- * renders as its own chip span now, so the formula is several text nodes.
+ * The formula cell showing `text`, optionally scoped to one row. Found by the hover-card slot the
+ * cell wraps itself in and then by its text: a resolved reference renders as its own chip span, so
+ * the formula is several text nodes and `getByText` matches none.
+ */
+function formulaCell(text: string, scope: ParentNode = document): HTMLElement {
+  const cells = [...scope.querySelectorAll<HTMLElement>('[data-slot="hover-card-trigger"]')];
+  const cell = cells.find(candidate => candidate.textContent === text);
+  if (!cell) throw new Error(`no formula cell showing "${text}"`);
+  return cell;
+}
+
+/**
+ * The formula cell's clickable trigger.
  */
 function formulaTrigger(text: string): HTMLElement {
-  const cell = screen.getByTitle(text);
+  const cell = formulaCell(text);
   return cell.querySelector<HTMLElement>('[data-slot="popover-trigger"]') ?? cell;
 }
 
@@ -515,7 +526,7 @@ describe('BaseSchemaTable — calculated field row', () => {
     );
 
     const row = screen.getByRole('row', { name: /ctr/ });
-    expect(within(row).getByTitle('SUM(clicks)').textContent).toBe('SUM(clicks)');
+    expect(formulaCell('SUM(clicks)', row).textContent).toBe('SUM(clicks)');
     expect(within(row).queryByText(/\{\{/)).not.toBeInTheDocument();
   });
 
@@ -530,7 +541,7 @@ describe('BaseSchemaTable — calculated field row', () => {
     );
 
     // Athena has no Mode column, so the band between Type and Σ available is those two columns.
-    expect(screen.getByTitle('SUM(clicks)').closest('td')).toHaveAttribute('colspan', '2');
+    expect(formulaCell('SUM(clicks)').closest('td')).toHaveAttribute('colspan', '2');
   });
 
   it('renders the ƒ icon on a calculated row and the ordinary status icon on a normal one', () => {
@@ -750,9 +761,8 @@ describe('BaseSchemaTable — calculated field row', () => {
       name: 'ctr',
       calculated: { formula: 'SUM({{ref field="clicks"}}) * 2' },
     });
-    // The edited field HAD a level, read back from an earlier save. It is dropped rather than
-    // carried onto a formula it no longer describes — the save derives the new one.
-    expect(updatedFields[1].calculated).not.toHaveProperty('level');
+    // The level rides along so the row does not change shape mid-edit; the save re-derives it.
+    expect(updatedFields[1].calculated).toHaveProperty('level', 'metric');
   });
 
   // The cell cannot know either of these on its own: the Data Mart arrives by context, and the
@@ -1015,7 +1025,7 @@ describe('BaseSchemaTable — calculated field row', () => {
       // replaces the cell before that guard ever runs. The band has to END before this column for
       // a row-level row, and this span is that seam — on a storage with no Mode column the band
       // is now the PK cell alone, which spans nothing (SchemaTable omits `colspan` at 1).
-      expect(within(row).getByTitle(ROW_LEVEL_TEXT).closest('td')).not.toHaveAttribute('colspan');
+      expect(formulaCell(ROW_LEVEL_TEXT, row).closest('td')).not.toHaveAttribute('colspan');
     });
 
     it('edits its own allowed set through that control, and the change is saved', async () => {
@@ -1065,8 +1075,8 @@ describe('BaseSchemaTable — calculated field row', () => {
         />
       );
 
-      const metricCell = screen.getByTitle('SUM(clicks)');
-      const rowLevelCell = screen.getByTitle(ROW_LEVEL_TEXT);
+      const metricCell = formulaCell('SUM(clicks)');
+      const rowLevelCell = formulaCell(ROW_LEVEL_TEXT);
 
       // Authoring form, never the stored tag — the same as a metric's.
       expect(rowLevelCell.textContent).toBe(ROW_LEVEL_TEXT);
@@ -1080,7 +1090,11 @@ describe('BaseSchemaTable — calculated field row', () => {
 
       // …and the row-level row's own Σ cell is the real one, not the formula drawn a second time.
       const row = screen.getByRole('row', { name: /doubled_clicks/ });
-      expect(within(row).getAllByTitle(ROW_LEVEL_TEXT)).toHaveLength(1);
+      expect(
+        [...row.querySelectorAll('[data-slot="hover-card-trigger"]')].filter(
+          cell => cell.textContent === ROW_LEVEL_TEXT
+        )
+      ).toHaveLength(1);
       expect(within(row).getByLabelText('Aggregations for doubled_clicks')).toBeInTheDocument();
     });
 
@@ -1095,7 +1109,7 @@ describe('BaseSchemaTable — calculated field row', () => {
 
       const row = screen.getByRole('row', { name: /ctr/ });
       expect(within(row).queryByLabelText(/aggregation/i)).not.toBeInTheDocument();
-      expect(within(row).getByTitle('SUM(clicks)').closest('td')).toHaveAttribute('colspan', '2');
+      expect(formulaCell('SUM(clicks)', row).closest('td')).toHaveAttribute('colspan', '2');
     });
 
     // A field authored in this session carries no level yet (the save derives it), and the
@@ -1115,7 +1129,7 @@ describe('BaseSchemaTable — calculated field row', () => {
 
       const row = screen.getByRole('row', { name: /doubled_clicks/ });
       expect(within(row).queryByLabelText(/aggregation/i)).not.toBeInTheDocument();
-      expect(within(row).getByTitle(ROW_LEVEL_TEXT).closest('td')).toHaveAttribute('colspan', '2');
+      expect(formulaCell(ROW_LEVEL_TEXT, row).closest('td')).toHaveAttribute('colspan', '2');
     });
 
     it('carries the same ƒ status icon a metric does', () => {
@@ -1138,14 +1152,25 @@ describe('BaseSchemaTable — calculated field row', () => {
       expect(screen.getAllByRole('img', { name: 'Calculated field' })).toHaveLength(2);
     });
 
-    // The level is DERIVED on save. Editing a row-level field's formula must drop the level read
-    // back from the previous save exactly as editing a metric's does — otherwise a formula that
-    // just gained an aggregate would be sent carrying `level: 'column'`.
-    it('drops the stored level when its formula is edited in place', () => {
+    // The level decides this row's SHAPE, and an absent one reads as aggregate — so dropping it
+    // on every edit took "Σ available" off a dimension the moment its formula was touched, and
+    // gave it back only after a save. It rides along instead; the save overwrites
+    // `calculated.level` from its own analysis, so what is sent decides nothing.
+    it('carries the stored level through an edit, and drops the warehouse stamp', () => {
       const onFieldsChange = vi.fn();
       render(
         <AthenaSchemaTable
-          fields={[buildAthenaField({ name: 'clicks' }), buildRowLevelField()]}
+          fields={[
+            buildAthenaField({ name: 'clicks' }),
+            {
+              ...buildRowLevelField(),
+              calculated: {
+                formula: ROW_LEVEL_FORMULA,
+                level: 'column',
+                warehouseValidation: 'passed',
+              },
+            } as AthenaSchemaField,
+          ]}
           onFieldsChange={onFieldsChange}
           schemaToolbar={mockSchemaToolbar}
         />
@@ -1158,7 +1183,40 @@ describe('BaseSchemaTable — calculated field row', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
       const [updatedFields] = onFieldsChange.mock.calls[0] as [AthenaSchemaField[]];
-      expect(updatedFields[1].calculated).toEqual({ formula: 'SUM({{ref field="clicks"}})' });
+      expect(updatedFields[1].calculated).toEqual({
+        formula: 'SUM({{ref field="clicks"}})',
+        level: 'column',
+      });
+    });
+
+    it('keeps its Σ available control after its formula is edited, before any save', () => {
+      const onFieldsChange = vi.fn();
+      const fields = [buildAthenaField({ name: 'clicks' }), buildRowLevelField()];
+      const { rerender } = render(
+        <AthenaSchemaTable
+          fields={fields}
+          onFieldsChange={onFieldsChange}
+          schemaToolbar={mockSchemaToolbar}
+        />
+      );
+
+      fireEvent.click(formulaTrigger(ROW_LEVEL_TEXT));
+      fireEvent.change(screen.getByTestId('formula-editor'), {
+        target: { value: 'UPPER(clicks)' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+      const [updatedFields] = onFieldsChange.mock.calls[0] as [AthenaSchemaField[]];
+      rerender(
+        <AthenaSchemaTable
+          fields={updatedFields}
+          onFieldsChange={onFieldsChange}
+          schemaToolbar={mockSchemaToolbar}
+        />
+      );
+
+      const row = screen.getAllByRole('row')[2];
+      expect(within(row).getByLabelText(/aggregation/i)).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
@@ -258,10 +258,15 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
             ? formula => {
                 saveCalculatedField(row.index, {
                   ...(row.original as SchemaField),
-                  // `calculated` is replaced wholesale, so a level read back from a PREVIOUS save
-                  // is dropped rather than carried onto a formula it no longer describes — the
-                  // save derives the new one.
-                  calculated: { formula },
+                  // `calculated` is replaced wholesale, so `warehouseValidation` goes: a stamp
+                  // must not outlive the formula it judged.
+                  //
+                  // The LEVEL is carried instead. It decides this row's shape, and an absent one
+                  // reads as aggregate — which took the "Σ available" control off a dimension the
+                  // moment its formula was touched, and put it back only after a save. Safe to
+                  // keep, because the save overwrites `calculated.level` from its own analysis
+                  // (CalculatedFieldValidatorService) rather than trusting what it was sent.
+                  calculated: { formula, level: row.original.calculated?.level },
                 });
               }
             : undefined

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.test.tsx
@@ -169,11 +169,22 @@ function buildCtrField(): BigQuerySchemaField {
 }
 
 /**
- * The formula cell's clickable trigger. Found by title rather than by text: a resolved reference
- * renders as its own chip span now, so the formula is several text nodes.
+ * The formula cell showing `text`, optionally scoped to one row. Found by the hover-card slot the
+ * cell wraps itself in and then by its text: a resolved reference renders as its own chip span, so
+ * the formula is several text nodes and `getByText` matches none.
+ */
+function formulaCell(text: string, scope: ParentNode = document): HTMLElement {
+  const cells = [...scope.querySelectorAll<HTMLElement>('[data-slot="hover-card-trigger"]')];
+  const cell = cells.find(candidate => candidate.textContent === text);
+  if (!cell) throw new Error(`no formula cell showing "${text}"`);
+  return cell;
+}
+
+/**
+ * The formula cell's clickable trigger.
  */
 function formulaTrigger(text: string): HTMLElement {
-  const cell = screen.getByTitle(text);
+  const cell = formulaCell(text);
   return cell.querySelector<HTMLElement>('[data-slot="popover-trigger"]') ?? cell;
 }
 
@@ -193,8 +204,7 @@ describe('BigQuerySchemaTable — calculated field (flattened-index correctness)
 
     // Mode + PK + Σ available: three columns that describe a warehouse column, none of which a
     // calculated field has.
-    const formulaCell = screen.getByTitle('SUM(id)').closest('td');
-    expect(formulaCell).toHaveAttribute('colspan', '3');
+    expect(formulaCell('SUM(id)').closest('td')).toHaveAttribute('colspan', '3');
   });
 
   it('a ROW-LEVEL row’s formula stops one column short — Σ available is its own', () => {
@@ -213,8 +223,8 @@ describe('BigQuerySchemaTable — calculated field (flattened-index correctness)
 
     // Mode + PK only. The metric beside it keeps all three, so this table renders two bands of
     // DIFFERENT lengths at once — what `RowCellSpan` had to grow to express.
-    expect(screen.getByTitle('id * 2').closest('td')).toHaveAttribute('colspan', '2');
-    expect(screen.getByTitle('SUM(id)').closest('td')).toHaveAttribute('colspan', '3');
+    expect(formulaCell('id * 2').closest('td')).toHaveAttribute('colspan', '2');
+    expect(formulaCell('SUM(id)').closest('td')).toHaveAttribute('colspan', '3');
 
     const row = screen.getByRole('row', { name: /doubled_id/ });
     expect(within(row).getByLabelText('Aggregations for doubled_id')).toBeInTheDocument();

--- a/docs/getting-started/setup-guide/calculated-fields.md
+++ b/docs/getting-started/setup-guide/calculated-fields.md
@@ -100,6 +100,28 @@ SUM(clicks) * 1.0 / NULLIF(SUM(impressions), 0)
 
 The guarded-division snippet inserts the plain form, so add the `* 1.0` yourself whenever both sides are integers.
 
+### A rate over a condition
+
+An activation rate, a share of paid accounts, a fill rate — all the same shape: count the rows that meet one condition, divide by the rows that meet another. Count with a conditional aggregate rather than filtering the Data Mart, so both counts come from the same rows at whatever grain the report asks for.
+
+```text
+COUNTIF(firstUsageDateTime IS NOT NULL) * 1.0
+  / NULLIF(COUNTIF(firstLogInDateTime IS NOT NULL), 0)
+```
+
+`COUNTIF` is BigQuery's spelling; Athena, Snowflake and Databricks call it `COUNT_IF`. Redshift has no conditional count, so count with a `CASE` there — which every dialect accepts:
+
+```text
+SUM(CASE WHEN firstUsageDateTime IS NOT NULL THEN 1 ELSE 0 END) * 1.0
+  / NULLIF(SUM(CASE WHEN firstLogInDateTime IS NOT NULL THEN 1 ELSE 0 END), 0)
+```
+
+Three things this shape depends on:
+
+- **`NULLIF(..., 0)`** — a period where nobody logged in gives an empty cell instead of failing the whole report with a division by zero.
+- **`* 1.0`** — both counts are integers, and on Redshift and Athena an integer divided by an integer truncates to `0`. See [Dividing one integer by another](#dividing-one-integer-by-another).
+- **Two arguments to `IFNULL`.** On BigQuery `IFNULL(x, 0, 1)` is not a shorter `IF` — `IFNULL` accepts exactly two. The editor's live check does not run the query, so a wrong-arity call is caught by the save's warehouse test run, not while you type. On BigQuery, `SAFE_DIVIDE(a, b)` is the guarded division in one call and needs no `NULLIF`.
+
 ### Aggregate Functions per Dialect
 
 These are the names OWOX recognises **as aggregates** when it reads your formula. Every storage offers the shared set:
@@ -228,7 +250,7 @@ When the joined Data Marts have not loaded, a dotted name is refused with _"coul
 
 Two outcomes are **warnings** and do not block the save:
 
-- **Unguarded division.** A `/` whose denominator is neither a number nor already wrapped in a null-guard is flagged so you can wrap it — `NULLIF(SUM(impressions), 0)` — but the formula still saves. Nothing is rewritten for you. This warning is about a **zero** denominator and nothing else: an integer-by-integer division is never flagged, on any storage — see [Dividing one integer by another](#dividing-one-integer-by-another).
+- **Unguarded division.** A `/` whose denominator is neither a number nor already wrapped in a zero-guard is flagged, naming the denominator it means, so you can wrap it — `NULLIF(SUM(impressions), 0)`. The formula still saves; nothing is rewritten for you. The warning is about a **zero** denominator and nothing else. Dividing by `NULL` is harmless — it simply returns `NULL` — which is why `COALESCE(SUM(impressions), 0)` does **not** count as a guard: it replaces a null with the very zero that fails the query. An integer-by-integer division is never flagged either, on any storage — see [Dividing one integer by another](#dividing-one-integer-by-another).
 - **The warehouse was unreachable.** The schema saves without the test run, says so by name, and the check runs again on the next save.
 
 ## Using the Field in a Report

--- a/docs/getting-started/setup-guide/calculated-fields.md
+++ b/docs/getting-started/setup-guide/calculated-fields.md
@@ -120,7 +120,7 @@ Three things this shape depends on:
 
 - **`NULLIF(..., 0)`** — a period where nobody logged in gives an empty cell instead of failing the whole report with a division by zero.
 - **`* 1.0`** — both counts are integers, and on Redshift and Athena an integer divided by an integer truncates to `0`. See [Dividing one integer by another](#dividing-one-integer-by-another).
-- **Two arguments to `IFNULL`.** On BigQuery `IFNULL(x, 0, 1)` is not a shorter `IF` — `IFNULL` accepts exactly two. The editor's live check does not run the query, so a wrong-arity call is caught by the save's warehouse test run, not while you type. On BigQuery, `SAFE_DIVIDE(a, b)` is the guarded division in one call and needs no `NULLIF`.
+- **`NULLIF`, not `IFNULL`.** The two names invite each other, and they do opposite things: `NULLIF(x, 0)` turns a zero into a null, which is the guard, while `IFNULL(x, 0)` turns a null into a zero — the very value that fails the division. `IFNULL` also takes exactly two arguments on BigQuery, so `IFNULL(x, 0, 1)` is not a shorter `IF`; the editor's live check never runs the query, so a wrong-arity call is caught by the save's warehouse test run rather than while you type. On BigQuery, `SAFE_DIVIDE(a, b)` is the guarded division in one call and needs no `NULLIF` at all.
 
 ### Aggregate Functions per Dialect
 

--- a/packages/ui/src/components/common/editable-text.tsx
+++ b/packages/ui/src/components/common/editable-text.tsx
@@ -2,7 +2,7 @@ import { Button } from '@owox/ui/components/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
 import { Textarea } from '@owox/ui/components/textarea';
 import { cn } from '@owox/ui/lib/utils';
-import { type KeyboardEvent, type ReactNode, useId, useRef, useState } from 'react';
+import { type KeyboardEvent, type ReactNode, useEffect, useId, useRef, useState } from 'react';
 
 /**
  * Helpers passed to a `editorAction` render-function so the action (e.g. AI generate)
@@ -85,6 +85,12 @@ export interface EditableTextProps {
    */
   onEditStart?: () => void;
   /**
+   * Called when the popover closes, however it closed — Apply, Cancel, Escape or a click outside.
+   * Pairs with `onEditStart` for owners that suppress something of their own while the editor is
+   * open; this component reports the transition because nothing outside it can observe one.
+   */
+  onEditEnd?: () => void;
+  /**
    * Heading for the open popover — which row is being edited, once the popover covers it. Omitted
    * by default, so a cell that does not ask for one looks exactly as it did.
    */
@@ -123,11 +129,19 @@ export function EditableText({
   renderEditor,
   onApply,
   onEditStart,
+  onEditEnd,
   editorTitle,
   editorHint,
   renderValue,
 }: EditableTextProps) {
   const [isEditing, setIsEditing] = useState(false);
+  // Reported from the state itself, not from the close handlers: Apply and Cancel both lower
+  // `isEditing` directly, so hooking any one route would miss the others.
+  const wasEditingRef = useRef(false);
+  useEffect(() => {
+    if (wasEditingRef.current && !isEditing) onEditEnd?.();
+    wasEditingRef.current = isEditing;
+  }, [isEditing, onEditEnd]);
   const [editedValue, setEditedValue] = useState(value);
   // Why an Apply can be refused: only `onApply` ever refuses one, so without it this stays null.
   const [applyError, setApplyError] = useState<string | null>(null);

--- a/packages/ui/src/components/hover-card.tsx
+++ b/packages/ui/src/components/hover-card.tsx
@@ -32,6 +32,7 @@ const HoverCardContent = React.forwardRef<
   return (
     <HoverCardPrimitive.Portal>
       <HoverCardPrimitive.Content
+        data-slot='hover-card-content'
         ref={ref}
         align={align}
         sideOffset={sideOffset}


### PR DESCRIPTION
## Summary

Six fixes to the **Calculated Field** editor, from feedback gathered in the first days of use of #6732. One branch, one commit, one changeset.

Fibery: [#6876 Calculated field improvments](https://owox.fibery.io/Sprint_Work/Work_Item/Calculated-field-improvments-6876)

## What's included

- **Unsaved edits survive a background refresh.** The Output Schema editor reset itself whenever `initialSchema` arrived as a new object, whether or not its content had changed — and every re-read of the Data Mart produces such an object. A formula typed but not yet saved went with it, while the failed save's errors stayed on screen naming a field no longer in the table. It compares by content now.
- **A row-level field keeps its "Σ available" control while its formula is edited.** Applying a formula replaced `calculated` wholesale, dropping the level the previous save derived; an absent level reads as aggregate-level, and an aggregate has no aggregations of its own. The level rides along now. The warehouse stamp is still dropped — it must not outlive the formula it judged.
- **A calculated field no longer stretches its row.** A formula authored over several lines made its row that many lines tall. The row clamps to two lines; hovering shows the whole formula with the author's own line breaks.
- **"Save & leave" names the rejected formula** instead of reporting `Request failed with status code 400`, which named neither the field nor the fix while the field-grouped detail sat on screen behind the dialog.
- **The unguarded-division warning is about the formula in front of you.** It quoted `NULLIF(SUM(impressions), 0)` whether or not `impressions` appeared anywhere in the formula, and read like a refusal although it refuses nothing. It quotes the denominator this formula actually divides by, underlines it, and says it is advice.
- **`COALESCE` no longer counts as a guard against that division.** What fails a query is a zero denominator, not a null one, and `COALESCE(SUM(x), 0)` produces exactly that zero.

Docs gain a worked example for a **rate over a condition** (activation rate, share of paid accounts, fill rate), asked for so agents have one to follow.

## The report that started it

An analyst reported a calculated field disappearing after a failed save. It had not been lost. The load balancer's own log shows exactly **six** `PUT /schema` calls on that Data Mart in 48 hours — five 400s and then a 200 — and every request body is within ~20 bytes of the others, so no payload ever lost a field. The field is in the Data Mart today with the formula that last save carried.

The defect was in the editor, not in the data, and that is the first item above.

## Measured, not assumed

- **Two lines are free.** A calculated row is **49px** whether its formula occupies one 16px line or two — the height comes from the controls beside it. The third line takes the row to 64px.
- **Not `whitespace-nowrap`.** It also bounds the height, but an unbreakable formula grew its column from **549px to 1042px** at the other columns' expense on this table's own widths.
- **Zero, not null.** On BigQuery `1 / CAST(NULL AS INT64)` returns NULL and raises nothing, while `1 / 0` and `1 / COALESCE(CAST(NULL AS INT64), 0)` both fail.

## What the warning quotes, and why it matters

The subject is now the **whole** denominator or nothing at all. Naming a fragment was worse than naming none: an analyst who wrapped what the message quoted got `revenue / (NULLIF(cost, 0) + tax)` — still fatal when `cost + tax` is zero, and now **silent**, because the guard sits exactly where the check looks.

| Formula | Before | After |
| --- | --- | --- |
| `revenue / (cost + tax)` | `cost` | `(cost + tax)` |
| `SUM(a) / CASE … END` | `CASE` | warns, names nothing |
| `SUM(a) / -1` | `-` | silent (a constant) |
| `SUM(a) / SUM(b` | `SUM` | warns, names nothing |

## Shared components

`EditableText` reports when its editor **closes**, so a cell can stand its hover card down while the editor's own popover is open. `HoverCardContent` gets the `data-slot` its sibling parts already carry.

## Testing

| | |
| --- | --- |
| `nest build` · `tsc -b` (web) | pass |
| backend `jest src/data-marts` | 434 suites, 7727 tests |
| web `vitest` | 245 files, 2295 tests |
| eslint (web, e2e, backend) · markdownlint | clean |

## For the reviewer

- The cell no longer carries the formula as its `title` — a native tooltip beside the hover card is a second, worse telling of the same thing. Nine Playwright locators moved to the slot the card puts there (`e2e/helpers/formula-cell.ts`), and the DSET-10 wrapping spec was rewritten against the new contract. **Playwright was not run locally**, so its first CI run is the real check on that migration.
- Both formula triggers take focus, so the card is reachable without a pointer. The clamp is visual only: the whole formula stays in the DOM, which is what a screen reader reads.
- Deliberately **not** in this PR, each worth its own change: `SAFE_DIVIDE` / `IFF` / `DIV0` still sit in the guard set although none of them guards a denominator (pre-existing, and a behaviour change with its own changeset); the warning's subject is whitespace-collapsed, which can stop the editor placing a marker on a multi-line denominator; and the hover card can be left open behind a suppressed state.
