### PR TITLE
perf(connectors): prune partitions in BigQuery incremental MERGE runs

### DIFF
--- a/.changeset/6880-bq-merge-partition-pruning.md
+++ b/.changeset/6880-bq-merge-partition-pruning.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Partition Pruning for BigQuery Connector Imports
+
+Incremental connector runs into Google BigQuery now scan only the partitions they write, not the whole destination table. Before, every incremental MERGE scanned the full table history, so daily import cost grew with table age. A measured example: one two-day import dropped from 1.16 GB scanned to 3.89 MB. The saving applies to time-series tables partitioned by date, such as ad performance reports. Entity tables without a date column keep their current behavior. This lowers query costs and helps connectors stay within BigQuery daily quotas.

--- a/packages/connectors/CREATING_CONNECTOR.md
+++ b/packages/connectors/CREATING_CONNECTOR.md
@@ -338,12 +338,15 @@ The flag has two effects:
 
 Two rules make the filter work:
 
-- The field type must be `DATE`, `DATETIME`, or `TIMESTAMP`.
+- The field type must be `DATE`, `DATETIME`, or `TIMESTAMP`. `DATETIME`
+  and `TIMESTAMP` fields get daily partitions via `_TRUNC`.
 - The node's `uniqueKeys` must include the field. Without it, the MERGE
   skips the filter and scans the whole table on every run.
 
-Time-series nodes should set both the flag and the `uniqueKeys` entry.
-Entity nodes without a date field need neither.
+Flag exactly one field per node. When several fields carry the flag, the
+last one selected for the table wins. Time-series nodes should set both
+the flag and the `uniqueKeys` entry. Entity nodes without a date field
+need neither.
 
 ## 6. Testing Your Connector
 

--- a/packages/connectors/CREATING_CONNECTOR.md
+++ b/packages/connectors/CREATING_CONNECTOR.md
@@ -339,7 +339,9 @@ The flag has two effects:
 Two rules make the filter work:
 
 - The field type must be `DATE`, `DATETIME`, or `TIMESTAMP`. `DATETIME`
-  and `TIMESTAMP` fields get daily partitions via `_TRUNC`.
+  and `TIMESTAMP` fields get daily partitions via `_TRUNC`. Any other type
+  skips partitioning: the table is created unpartitioned and the run log
+  records the skipped column.
 - The node's `uniqueKeys` must include the field. Without it, the MERGE
   skips the filter and scans the whole table on every run.
 

--- a/packages/connectors/CREATING_CONNECTOR.md
+++ b/packages/connectors/CREATING_CONNECTOR.md
@@ -318,6 +318,33 @@ constructor(config) {
 }
 ```
 
+### Partitioning in Google BigQuery
+
+Mark one date-like field per node with `GoogleBigQueryPartitioned: true`:
+
+```javascript
+date: {
+  description: 'The date for this metric.',
+  type: DATA_TYPES.DATE,
+  GoogleBigQueryPartitioned: true
+}
+```
+
+The flag has two effects:
+
+- New destination tables get `PARTITION BY` on this field.
+- Incremental MERGE runs add a date-range filter on the target table.
+  BigQuery then scans only the partitions being written, not the full table.
+
+Two rules make the filter work:
+
+- The field type must be `DATE`, `DATETIME`, or `TIMESTAMP`.
+- The node's `uniqueKeys` must include the field. Without it, the MERGE
+  skips the filter and scans the whole table on every run.
+
+Time-series nodes should set both the flag and the `uniqueKeys` entry.
+Entity nodes without a date field need neither.
+
 ## 6. Testing Your Connector
 
 After creating your connector:

--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -160,7 +160,7 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
           WHERE schema_name = '${this.config.DestinationDatasetName.value}'
         );
         IF dataset_exists THEN 
-          SELECT column_name, data_type
+          SELECT column_name, data_type, is_partitioning_column
           FROM \`${this.config.DestinationDatasetID.value}.INFORMATION_SCHEMA.COLUMNS\`
           WHERE table_name = '${this.config.DestinationTableName.value}'
           ORDER BY ordinal_position;
@@ -176,11 +176,11 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
 
         if( queryResults.rows ) {
           queryResults.rows.map(row => {
-            columns[ row.f[0].v ]  = {"name": row.f[0].v, "type": row.f[1].v}
+            columns[ row.f[0].v ]  = {"name": row.f[0].v, "type": row.f[1].v, "isPartitioningColumn": row.f[2].v === "YES"}
           });
         } else if (Array.isArray(queryResults)) {
           queryResults.map(row => {
-            columns[ row.column_name ] = {"name": row.column_name, "type": row.data_type}
+            columns[ row.column_name ] = {"name": row.column_name, "type": row.data_type, "isPartitioningColumn": row.is_partitioning_column === "YES"}
           });
         }
 
@@ -202,24 +202,11 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
 
     }
 
-  //---- getPartitionColumn ------------------------------------------
-    /**
-     * Finds the schema field flagged as the BigQuery partition column
-     * @return {string|null} - the column name, or null when the schema declares none
-     */
-    getPartitionColumn() {
-      for (const columnName in this.schema) {
-        if( this.schema[ columnName ] && this.schema[ columnName ]["GoogleBigQueryPartitioned"] ) {
-          return columnName;
-        }
-      }
-      return null;
-    }
-
   //---- createTableIfItDoesntExist ----------------------------------
     async createTableIfItDoesntExist(quoteColumnNames = false) {
 
       let columns = [];
+      let columnPartitioned = null;
       let existingColumns = {};
 
       let selectedFields = this.getSelectedFields();
@@ -239,6 +226,13 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
           columnDescription = ` OPTIONS(description="${this.obfuscateSpecialCharacters(this.schema[ columnName ]["description"])}")`;
         }
 
+        // Last flagged column wins — LinkedIn flags two; existing tables
+        // were created under this rule, so it must not change
+        if( "GoogleBigQueryPartitioned" in this.schema[ columnName ]
+        && this.schema[ columnName ]["GoogleBigQueryPartitioned"] ) {
+          columnPartitioned = columnName;
+        }
+
         const sqlColumnName = quoteColumnNames ? quoteBigQueryIdentifier(columnName) : columnName;
         columns.push(`${sqlColumnName} ${columnType}${columnDescription}`);
         
@@ -256,11 +250,14 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       let query = `---- Creating table if it not exists -----\n`;
       query += `CREATE TABLE IF NOT EXISTS \`${this.config.DestinationDatasetID.value}.${this.config.DestinationTableName.value}\` (\n${columns})`
 
-      // The partition column must be among the columns actually created:
-      // a schema may flag a field the user did not select for this table.
-      const columnPartitioned = this.getPartitionColumn();
-      if( columnPartitioned && tableColumns.includes(columnPartitioned) ) {
-        query += `\nPARTITION BY ${quoteColumnNames ? quoteBigQueryIdentifier(columnPartitioned) : columnPartitioned}`;
+      if( columnPartitioned ) {
+        const sqlName = quoteColumnNames ? quoteBigQueryIdentifier(columnPartitioned) : columnPartitioned;
+        const partitionExpression = this.buildPartitionByExpression(sqlName, this.getColumnType(columnPartitioned));
+        if( partitionExpression ) {
+          query += `\nPARTITION BY ${partitionExpression}`;
+          // Record table truth for buildPartitionPredicate in same-run flows
+          existingColumns[ columnPartitioned ]["isPartitioningColumn"] = true;
+        }
       }
 
       if( this.description ) {
@@ -614,6 +611,43 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       return this.obfuscateSpecialCharacters( rawValue );
     }
 
+  //---- buildPartitionByExpression ----------------------------------
+    /**
+     * DDL expression for PARTITION BY, or null for types BigQuery cannot
+     * partition by. DATETIME/TIMESTAMP columns need daily truncation.
+     */
+    buildPartitionByExpression(sqlColumnName, columnType) {
+      switch( String(columnType).toUpperCase() ) {
+        case "DATE": return sqlColumnName;
+        case "DATETIME": return `DATETIME_TRUNC(${sqlColumnName}, DAY)`;
+        case "TIMESTAMP": return `TIMESTAMP_TRUNC(${sqlColumnName}, DAY)`;
+        default: return null;
+      }
+    }
+
+  //---- isRealCalendarValue -----------------------------------------
+    /**
+     * True when a canonical 'YYYY-MM-DD[ HH:MM:SS]' string denotes a real
+     * calendar date and time. The shape regex accepts impossible values like
+     * 2026-02-31; SAFE_CAST turns those into NULL inside source rows, but a
+     * typed literal in the predicate would fail the whole query.
+     */
+    isRealCalendarValue(value) {
+      const [datePart, timePart] = value.split(" ");
+      const [year, month, day] = datePart.split("-").map(Number);
+      const date = new Date(Date.UTC(year, month - 1, day));
+      if( date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day ) {
+        return false;
+      }
+      if( timePart ) {
+        const [hours, minutes, seconds] = timePart.split(":").map(Number);
+        if( hours > 23 || minutes > 59 || seconds > 59 ) {
+          return false;
+        }
+      }
+      return true;
+    }
+
   //---- buildPartitionPredicate -------------------------------------
     /**
      * Builds a constant partition filter for the MERGE ON clause, so BigQuery
@@ -621,10 +655,16 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
      * `target.date = source.date` alone does not prune: the source is a
      * subquery of literals, and pruning needs a constant filter on the target.
      *
-     * Returns null (no predicate, today's full-scan behavior) whenever the
-     * range cannot be derived safely: no partition column in the schema, the
-     * column is missing from the destination table, any record lacks a value,
-     * or a value does not look like a date/datetime literal.
+     * The partition column is taken from the destination table itself
+     * (INFORMATION_SCHEMA, or recorded at CREATE TABLE time), not from the
+     * schema flag: a legacy table can be partitioned by a different flagged
+     * field, or by nothing at all.
+     *
+     * Returns null (no predicate, the MERGE falls back to a full table scan)
+     * whenever the range cannot be derived safely: the destination table has
+     * no partitioning column, that column is not part of the unique key, its
+     * type is not date-like, any record lacks a value, or a value is not a
+     * real calendar date/time in canonical shape.
      *
      * @param {Array} recordKeys - Record keys of the batch being merged
      * @return {string|null} - SQL predicate for the target table, or null
@@ -643,7 +683,13 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
         "TIMESTAMP": /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/
       };
 
-      const partitionColumn = this.getPartitionColumn();
+      // The destination table's real partitioning column, as reported by
+      // INFORMATION_SCHEMA or recorded at CREATE TABLE time. The schema flag
+      // is not trusted here: a legacy table can be partitioned by a different
+      // flagged field (LinkedIn flags two), or by nothing at all.
+      const partitionColumn = Object.keys(this.existingColumns).find(
+        name => this.existingColumns[ name ] && this.existingColumns[ name ]["isPartitioningColumn"]
+      );
       if( !partitionColumn ) {
         return null;
       }
@@ -657,11 +703,7 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
         return null;
       }
 
-      // A table created before the schema gained the flag has no such column
       const columnInfo = this.existingColumns[ partitionColumn ];
-      if( !columnInfo ) {
-        return null;
-      }
 
       const columnType = String(columnInfo.type).toUpperCase();
       const literalPattern = DATE_LIKE_LITERALS[ columnType ];
@@ -679,9 +721,10 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
         // batch mixing them still has one uniform, comparable shape
         const value = typeof formatted === "string" ? formatted.replace("T", " ") : formatted;
 
-        // One unusable value and the whole predicate is off: a predicate that
-        // misses a record's partition would silently drop that record's update
-        if( typeof value !== "string" || !literalPattern.test(value) ) {
+        // One unusable value and the whole predicate is off: a range that
+        // misses a record's partition would hide its target row from the
+        // MERGE and insert a duplicate instead of updating it
+        if( typeof value !== "string" || !literalPattern.test(value) || !this.isRealCalendarValue(value) ) {
           return null;
         }
 

--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -257,6 +257,10 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
           query += `\nPARTITION BY ${partitionExpression}`;
           // Record table truth for buildPartitionPredicate in same-run flows
           existingColumns[ columnPartitioned ]["isPartitioningColumn"] = true;
+        } else {
+          // A silent skip here would ship a dead flag: the table is created
+          // unpartitioned and every MERGE full-scans with no symptom but cost
+          this.config.logMessage(`Column '${columnPartitioned}' has type '${this.getColumnType(columnPartitioned)}' which cannot be a partition column; creating the table without partitioning`);
         }
       }
 
@@ -593,22 +597,37 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
     formatColumnValue(rawValue, columnType) {
 
       if (rawValue === undefined || rawValue === null) {
-
         return null;
-
-      } else if( ( columnType.toUpperCase() == "DATE") && (rawValue instanceof Date) ) {
-
-        return DateUtils.formatDate( rawValue );
-
-      } else if( (columnType.toUpperCase() == "DATETIME") && (rawValue instanceof Date) ) {
-
-        // Format as YYYY-MM-DD HH:MM:SS for BigQuery DATETIME
-        const isoString = rawValue.toISOString();
-        return isoString.replace('T', ' ').substring(0, 19);
-
       }
 
-      return this.obfuscateSpecialCharacters( rawValue );
+      const type = String(columnType).toUpperCase();
+      // instanceof alone fails across realms (the Apps Script target); the
+      // constructor-name fallback matches getUniqueKeyByRecordFields and
+      // stringifyNeastedFields in AbstractStorage
+      const isDateValue = rawValue instanceof Date
+        || (typeof rawValue === "object" && rawValue.constructor && rawValue.constructor.name == "Date");
+
+      if( type == "DATE" && isDateValue ) {
+        return DateUtils.formatDate( rawValue );
+      }
+
+      if( (type == "DATETIME" || type == "TIMESTAMP") && isDateValue ) {
+        // YYYY-MM-DD HH:MM:SS — toISOString is UTC, which is exactly what a
+        // zone-less BigQuery TIMESTAMP literal denotes
+        const isoString = rawValue.toISOString();
+        return isoString.replace('T', ' ').substring(0, 19);
+      }
+
+      const stringValue = this.obfuscateSpecialCharacters( rawValue );
+
+      if( type == "DATETIME" || type == "TIMESTAMP" ) {
+        // 'T' and ' ' separators are equivalent to BigQuery; normalizing in
+        // the shared helper keeps source rows and the partition predicate
+        // comparable by construction rather than by coincidence
+        return stringValue.replace("T", " ");
+      }
+
+      return stringValue;
     }
 
   //---- buildPartitionByExpression ----------------------------------
@@ -636,6 +655,9 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       const [datePart, timePart] = value.split(" ");
       const [year, month, day] = datePart.split("-").map(Number);
       const date = new Date(Date.UTC(year, month - 1, day));
+      // Date.UTC maps years 0-99 to 1900-1999, so this round-trip also
+      // rejects years 0001-0099 (legal in BigQuery, absent in ad data).
+      // Deliberate: the same quirk is what rejects garbage like '0000-00-00'.
       if( date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day ) {
         return false;
       }
@@ -646,6 +668,20 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
         }
       }
       return true;
+    }
+
+  //---- suppressPartitionPredicate ----------------------------------
+    /**
+     * Logs once per run why partition pruning is off — so a full-scan MERGE
+     * is distinguishable from pruning working as intended — then returns
+     * null for buildPartitionPredicate to pass through.
+     */
+    suppressPartitionPredicate(reason) {
+      if( !this._partitionPredicateSuppressionLogged ) {
+        this._partitionPredicateSuppressionLogged = true;
+        this.config.logMessage(`Partition pruning is disabled for this run (${reason}); MERGE scans the whole table`);
+      }
+      return null;
     }
 
   //---- buildPartitionPredicate -------------------------------------
@@ -663,8 +699,12 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
      * Returns null (no predicate, the MERGE falls back to a full table scan)
      * whenever the range cannot be derived safely: the destination table has
      * no partitioning column, that column is not part of the unique key, its
-     * type is not date-like, any record lacks a value, or a value is not a
-     * real calendar date/time in canonical shape.
+     * type is not date-like, no record carries a partition value, or a value
+     * is not a real calendar date/time in canonical shape. Records with a
+     * NULL partition value are skipped instead of suppressing the predicate:
+     * their source rows can only INSERT, so no target range affects them.
+     * Every suppression except the missing partition column logs its reason
+     * once per run via suppressPartitionPredicate().
      *
      * @param {Array} recordKeys - Record keys of the batch being merged
      * @return {string|null} - SQL predicate for the target table, or null
@@ -700,7 +740,7 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       // Without this, a matching target row in an out-of-range partition would
       // be invisible to the MERGE and its source row inserted as a duplicate.
       if( !this.uniqueKeyColumns || !this.uniqueKeyColumns.includes(partitionColumn) ) {
-        return null;
+        return this.suppressPartitionPredicate(`partition column '${partitionColumn}' is not part of the unique key`);
       }
 
       const columnInfo = this.existingColumns[ partitionColumn ];
@@ -708,7 +748,7 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       const columnType = String(columnInfo.type).toUpperCase();
       const literalPattern = DATE_LIKE_LITERALS[ columnType ];
       if( !literalPattern ) {
-        return null;
+        return this.suppressPartitionPredicate(`partition column '${partitionColumn}' has non-date type '${columnInfo.type}'`);
       }
 
       let minValue = null;
@@ -716,16 +756,22 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
 
       for (const key of recordKeys) {
         const record = this.updatedRecordsBuffer[ key ];
-        const formatted = this.formatColumnValue( record ? record[ partitionColumn ] : null, columnType );
-        // 'T' and ' ' separators are equivalent to BigQuery; normalize so a
-        // batch mixing them still has one uniform, comparable shape
-        const value = typeof formatted === "string" ? formatted.replace("T", " ") : formatted;
+        const value = this.formatColumnValue( record ? record[ partitionColumn ] : null, columnType );
 
-        // One unusable value and the whole predicate is off: a range that
-        // misses a record's partition would hide its target row from the
-        // MERGE and insert a duplicate instead of updating it
+        // A record without a partition value emits SAFE_CAST(NULL ...) in its
+        // source row: NULL never equals any target value, so the row is an
+        // INSERT either way and no target range can affect it — skip it
+        // rather than giving up on pruning for the whole batch
+        if( value === null ) {
+          continue;
+        }
+
+        // One malformed value and the whole predicate is off: unlike NULL, a
+        // string this regex rejects may still SAFE_CAST to a real value in
+        // the source row, and a range that misses that row's partition would
+        // hide its target row from the MERGE and insert a duplicate
         if( typeof value !== "string" || !literalPattern.test(value) || !this.isRealCalendarValue(value) ) {
-          return null;
+          return this.suppressPartitionPredicate(`a record value in '${partitionColumn}' is not a canonical date/datetime`);
         }
 
         if( minValue === null || value < minValue ) minValue = value;
@@ -733,7 +779,7 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       }
 
       if( minValue === null ) {
-        return null;
+        return this.suppressPartitionPredicate(`no record carries a value in partition column '${partitionColumn}'`);
       }
 
       const targetColumn = `target.${this.formatFieldIdentifier(partitionColumn)}`;

--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -202,11 +202,24 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
 
     }
 
+  //---- getPartitionColumn ------------------------------------------
+    /**
+     * Finds the schema field flagged as the BigQuery partition column
+     * @return {string|null} - the column name, or null when the schema declares none
+     */
+    getPartitionColumn() {
+      for (const columnName in this.schema) {
+        if( this.schema[ columnName ] && this.schema[ columnName ]["GoogleBigQueryPartitioned"] ) {
+          return columnName;
+        }
+      }
+      return null;
+    }
+
   //---- createTableIfItDoesntExist ----------------------------------
     async createTableIfItDoesntExist(quoteColumnNames = false) {
 
       let columns = [];
-      let columnPartitioned = null;
       let existingColumns = {};
 
       let selectedFields = this.getSelectedFields();
@@ -226,11 +239,6 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
           columnDescription = ` OPTIONS(description="${this.obfuscateSpecialCharacters(this.schema[ columnName ]["description"])}")`;
         }
 
-        if( "GoogleBigQueryPartitioned" in this.schema[ columnName ] 
-        && this.schema[ columnName ]["GoogleBigQueryPartitioned"] ) {
-          columnPartitioned = columnName;
-        }
-
         const sqlColumnName = quoteColumnNames ? quoteBigQueryIdentifier(columnName) : columnName;
         columns.push(`${sqlColumnName} ${columnType}${columnDescription}`);
         
@@ -248,7 +256,10 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       let query = `---- Creating table if it not exists -----\n`;
       query += `CREATE TABLE IF NOT EXISTS \`${this.config.DestinationDatasetID.value}.${this.config.DestinationTableName.value}\` (\n${columns})`
 
-      if( columnPartitioned ) {
+      // The partition column must be among the columns actually created:
+      // a schema may flag a field the user did not select for this table.
+      const columnPartitioned = this.getPartitionColumn();
+      if( columnPartitioned && tableColumns.includes(columnPartitioned) ) {
         query += `\nPARTITION BY ${quoteColumnNames ? quoteBigQueryIdentifier(columnPartitioned) : columnPartitioned}`;
       }
 
@@ -575,6 +586,117 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       }
     }
 
+  //---- formatColumnValue -------------------------------------------
+    /**
+     * Casts a record value to the string form used in generated SQL
+     * @param {*} rawValue - the raw record value
+     * @param {string} columnType - the BigQuery column type
+     * @return {string|null} - the formatted value, or null for missing values
+     */
+    formatColumnValue(rawValue, columnType) {
+
+      if (rawValue === undefined || rawValue === null) {
+
+        return null;
+
+      } else if( ( columnType.toUpperCase() == "DATE") && (rawValue instanceof Date) ) {
+
+        return DateUtils.formatDate( rawValue );
+
+      } else if( (columnType.toUpperCase() == "DATETIME") && (rawValue instanceof Date) ) {
+
+        // Format as YYYY-MM-DD HH:MM:SS for BigQuery DATETIME
+        const isoString = rawValue.toISOString();
+        return isoString.replace('T', ' ').substring(0, 19);
+
+      }
+
+      return this.obfuscateSpecialCharacters( rawValue );
+    }
+
+  //---- buildPartitionPredicate -------------------------------------
+    /**
+     * Builds a constant partition filter for the MERGE ON clause, so BigQuery
+     * prunes partitions instead of scanning the whole target table.
+     * `target.date = source.date` alone does not prune: the source is a
+     * subquery of literals, and pruning needs a constant filter on the target.
+     *
+     * Returns null (no predicate, today's full-scan behavior) whenever the
+     * range cannot be derived safely: no partition column in the schema, the
+     * column is missing from the destination table, any record lacks a value,
+     * or a value does not look like a date/datetime literal.
+     *
+     * @param {Array} recordKeys - Record keys of the batch being merged
+     * @return {string|null} - SQL predicate for the target table, or null
+     */
+    buildPartitionPredicate(recordKeys) {
+
+      // Exactly one fixed-width shape per type: min/max below compares strings
+      // lexicographically, which matches chronological order only when every
+      // value has the same width and no zone marker. Fractions, Z and offsets
+      // are rejected on purpose — mixed shapes in one batch would let the
+      // string min/max diverge from the true time range and produce a BETWEEN
+      // that excludes rows the MERGE must see.
+      const DATE_LIKE_LITERALS = {
+        "DATE": /^\d{4}-\d{2}-\d{2}$/,
+        "DATETIME": /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+        "TIMESTAMP": /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/
+      };
+
+      const partitionColumn = this.getPartitionColumn();
+      if( !partitionColumn ) {
+        return null;
+      }
+
+      // The predicate is only safe when the partition column is part of the
+      // unique key: the ON clause then already contains
+      // `target.<col> = source.<col>`, so bounding the target changes nothing.
+      // Without this, a matching target row in an out-of-range partition would
+      // be invisible to the MERGE and its source row inserted as a duplicate.
+      if( !this.uniqueKeyColumns || !this.uniqueKeyColumns.includes(partitionColumn) ) {
+        return null;
+      }
+
+      // A table created before the schema gained the flag has no such column
+      const columnInfo = this.existingColumns[ partitionColumn ];
+      if( !columnInfo ) {
+        return null;
+      }
+
+      const columnType = String(columnInfo.type).toUpperCase();
+      const literalPattern = DATE_LIKE_LITERALS[ columnType ];
+      if( !literalPattern ) {
+        return null;
+      }
+
+      let minValue = null;
+      let maxValue = null;
+
+      for (const key of recordKeys) {
+        const record = this.updatedRecordsBuffer[ key ];
+        const formatted = this.formatColumnValue( record ? record[ partitionColumn ] : null, columnType );
+        // 'T' and ' ' separators are equivalent to BigQuery; normalize so a
+        // batch mixing them still has one uniform, comparable shape
+        const value = typeof formatted === "string" ? formatted.replace("T", " ") : formatted;
+
+        // One unusable value and the whole predicate is off: a predicate that
+        // misses a record's partition would silently drop that record's update
+        if( typeof value !== "string" || !literalPattern.test(value) ) {
+          return null;
+        }
+
+        if( minValue === null || value < minValue ) minValue = value;
+        if( maxValue === null || value > maxValue ) maxValue = value;
+      }
+
+      if( minValue === null ) {
+        return null;
+      }
+
+      const targetColumn = `target.${this.formatFieldIdentifier(partitionColumn)}`;
+      return `${targetColumn} BETWEEN ${columnType} '${minValue}' AND ${columnType} '${maxValue}'`;
+    }
+
   //---- buildMergeQuery ---------------------------------------------
     /**
      * Builds a MERGE query for the specified record keys
@@ -593,29 +715,8 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
 
           let columnName = this.existingColumns[j]["name"];
           let columnType = this.existingColumns[j]["type"];
-          let columnValue = null;
+          let columnValue = this.formatColumnValue( record[ columnName ], columnType );
 
-          if (record[columnName] === undefined || record[columnName] === null) {
-
-            columnValue = null;
-
-          } else if( ( columnType.toUpperCase() == "DATE") && (record[ columnName ] instanceof Date) ) {
-
-            columnValue = DateUtils.formatDate( record[ columnName ] );
-
-          } else if( (columnType.toUpperCase() == "DATETIME") && (record[ columnName ] instanceof Date) ) {
-
-            // Format as YYYY-MM-DD HH:MM:SS for BigQuery DATETIME
-            const isoString = record[ columnName ].toISOString();
-            columnValue = isoString.replace('T', ' ').substring(0, 19);
-
-          } else {
-
-            columnValue = this.obfuscateSpecialCharacters( record[ columnName ] );
-
-          }
-          
-          
           if (columnValue === null) {
             fields.push(`SAFE_CAST(NULL AS ${columnType}) ${this.formatFieldIdentifier(columnName)}`);
           } else {
@@ -628,12 +729,17 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       }
        
       let existingColumnsNames = Object.keys(this.existingColumns);
+
+      // Constant filter on the target's partition column enables partition
+      // pruning; without it every MERGE scans the whole destination table
+      const partitionPredicate = this.buildPartitionPredicate(recordKeys);
+
       let query = `MERGE INTO \`${this.config.DestinationDatasetID.value}.${this.config.DestinationTableName.value}\` AS target
       USING (
         ${rows.join("\n\nUNION ALL\n\n")}
       ) AS source
-      
-      ON ${this.uniqueKeyColumns.map(item => (`target.${this.formatFieldIdentifier(item)} = source.${this.formatFieldIdentifier(item)}`)).join("\n AND ")}
+
+      ON ${this.uniqueKeyColumns.map(item => (`target.${this.formatFieldIdentifier(item)} = source.${this.formatFieldIdentifier(item)}`)).join("\n AND ")}${partitionPredicate ? `\n AND ${partitionPredicate}` : ""}
 
         WHEN MATCHED THEN
         UPDATE SET

--- a/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
+++ b/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
@@ -137,7 +137,7 @@ describe('buildMergeQuery partition pruning', () => {
       },
       existingColumns: {
         ad_id: { name: 'ad_id', type: 'STRING' },
-        date: { name: 'date', type: 'DATE' },
+        date: { name: 'date', type: 'DATE', isPartitioningColumn: true },
         impressions: { name: 'impressions', type: 'INT64' },
       },
       updatedRecordsBuffer: {
@@ -186,8 +186,9 @@ describe('buildMergeQuery partition pruning', () => {
   });
 
   it('suppresses the predicate when any record lacks a partition value', () => {
-    // A predicate that misses one record's partition would silently drop that
-    // record's update, so one gap disables pruning for the whole batch.
+    // A range that misses one record's partition would hide its target row
+    // and produce a duplicate insert, so one gap disables pruning for the
+    // whole batch.
     const storage = mergeStorage();
     storage.updatedRecordsBuffer['ad_1|2026-08-30'].date = null;
 
@@ -230,7 +231,7 @@ describe('buildMergeQuery partition pruning', () => {
     const storage = mergeStorage({
       existingColumns: {
         ad_id: { name: 'ad_id', type: 'STRING' },
-        date: { name: 'date', type: 'TIMESTAMP' },
+        date: { name: 'date', type: 'TIMESTAMP', isPartitioningColumn: true },
         impressions: { name: 'impressions', type: 'INT64' },
       },
       updatedRecordsBuffer: {
@@ -246,7 +247,7 @@ describe('buildMergeQuery partition pruning', () => {
     const storage = mergeStorage({
       existingColumns: {
         ad_id: { name: 'ad_id', type: 'STRING' },
-        date: { name: 'date', type: 'DATETIME' },
+        date: { name: 'date', type: 'DATETIME', isPartitioningColumn: true },
         impressions: { name: 'impressions', type: 'INT64' },
       },
       updatedRecordsBuffer: {
@@ -260,11 +261,56 @@ describe('buildMergeQuery partition pruning', () => {
     );
   });
 
+  it('suppresses the predicate for an impossible calendar date', () => {
+    // Shape-valid but not a real date: SAFE_CAST makes it NULL in source
+    // rows, but DATE '2026-02-31' in the predicate would fail the whole query.
+    const storage = mergeStorage();
+    storage.updatedRecordsBuffer['ad_1|2026-08-30'].date = '2026-02-31';
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBeNull();
+  });
+
+  it('suppresses the predicate for an out-of-range time', () => {
+    const storage = mergeStorage({
+      existingColumns: {
+        ad_id: { name: 'ad_id', type: 'STRING' },
+        date: { name: 'date', type: 'DATETIME', isPartitioningColumn: true },
+        impressions: { name: 'impressions', type: 'INT64' },
+      },
+      updatedRecordsBuffer: {
+        a: { ad_id: 'ad_1', date: '2026-08-30 25:00:00', impressions: 1 },
+      },
+    });
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBeNull();
+  });
+
+  it('follows the table partitioning column when the schema flags a different field', () => {
+    // LinkedIn flags both dateRangeStart and dateRangeEnd; existing tables
+    // are partitioned by dateRangeEnd. Table truth must win over the schema.
+    const storage = mergeStorage({
+      uniqueKeyColumns: ['dateRangeStart', 'dateRangeEnd', 'pivotValues'],
+      existingColumns: {
+        dateRangeStart: { name: 'dateRangeStart', type: 'DATE' },
+        dateRangeEnd: { name: 'dateRangeEnd', type: 'DATE', isPartitioningColumn: true },
+        pivotValues: { name: 'pivotValues', type: 'STRING' },
+      },
+      updatedRecordsBuffer: {
+        a: { dateRangeStart: '2026-08-29', dateRangeEnd: '2026-08-30', pivotValues: 'x' },
+        b: { dateRangeStart: '2026-08-30', dateRangeEnd: '2026-08-31', pivotValues: 'y' },
+      },
+    });
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBe(
+      "target.dateRangeEnd BETWEEN DATE '2026-08-30' AND DATE '2026-08-31'"
+    );
+  });
+
   it('uses a TIMESTAMP literal for a TIMESTAMP partition column', () => {
     const storage = mergeStorage({
       existingColumns: {
         ad_id: { name: 'ad_id', type: 'STRING' },
-        date: { name: 'date', type: 'TIMESTAMP' },
+        date: { name: 'date', type: 'TIMESTAMP', isPartitioningColumn: true },
         impressions: { name: 'impressions', type: 'INT64' },
       },
       updatedRecordsBuffer: {

--- a/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
+++ b/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
@@ -128,6 +128,7 @@ describe('buildMergeQuery partition pruning', () => {
       config: {
         DestinationDatasetID: configValue('project.dataset'),
         DestinationTableName: configValue('reddit_ads_report'),
+        logMessage() {},
       },
       uniqueKeyColumns: ['ad_id', 'date'],
       schema: {
@@ -185,14 +186,37 @@ describe('buildMergeQuery partition pruning', () => {
     expect(query).toContain('ON target.id = source.id');
   });
 
-  it('suppresses the predicate when any record lacks a partition value', () => {
-    // A range that misses one record's partition would hide its target row
-    // and produce a duplicate insert, so one gap disables pruning for the
-    // whole batch.
+  it('skips records without a partition value instead of disabling pruning', () => {
+    // A NULL partition value emits SAFE_CAST(NULL ...), which never equals
+    // any target value — the record is INSERT-only either way, so the range
+    // can ignore it and still cover every matchable row.
     const storage = mergeStorage();
     storage.updatedRecordsBuffer['ad_1|2026-08-30'].date = null;
 
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBe(
+      "target.date BETWEEN DATE '2026-08-29' AND DATE '2026-08-31'"
+    );
+  });
+
+  it('emits no predicate when every record lacks a partition value', () => {
+    const storage = mergeStorage();
+    for (const key of Object.keys(storage.updatedRecordsBuffer)) {
+      storage.updatedRecordsBuffer[key].date = null;
+    }
+
     expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBeNull();
+  });
+
+  it('logs the suppression reason once per run, not once per batch', () => {
+    const messages = [];
+    const storage = mergeStorage({ uniqueKeyColumns: ['ad_id'] });
+    storage.config.logMessage = message => messages.push(message);
+
+    storage.buildPartitionPredicate(bufferKeys(storage));
+    storage.buildPartitionPredicate(bufferKeys(storage));
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("'date' is not part of the unique key");
   });
 
   it('suppresses the predicate when the partition column is not part of the unique key', () => {
@@ -322,5 +346,147 @@ describe('buildMergeQuery partition pruning', () => {
     expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBe(
       "target.date BETWEEN TIMESTAMP '2026-08-30 10:00:00' AND TIMESTAMP '2026-08-31 09:30:00'"
     );
+  });
+});
+
+describe('getAListOfExistingColumns', () => {
+  // The only production source of isPartitioningColumn — if either parsing
+  // branch stops matching, the predicate silently never fires while every
+  // other test still passes. These two pin the producers.
+  const columnsStorage = () =>
+    Object.assign(Object.create(proto), {
+      config: {
+        DestinationProjectID: configValue('project'),
+        DestinationDatasetName: configValue('dataset'),
+        DestinationDatasetID: configValue('project.dataset'),
+        DestinationTableName: configValue('reddit_ads_report'),
+      },
+    });
+
+  it('marks the partitioning column in the BigQuery row/field result shape', async () => {
+    const storage = columnsStorage();
+    storage.executeQuery = async () => ({
+      rows: [
+        { f: [{ v: 'ad_id' }, { v: 'STRING' }, { v: 'NO' }] },
+        { f: [{ v: 'date' }, { v: 'DATE' }, { v: 'YES' }] },
+      ],
+    });
+
+    const columns = await storage.getAListOfExistingColumns();
+
+    expect(columns.date).toEqual({ name: 'date', type: 'DATE', isPartitioningColumn: true });
+    expect(columns.ad_id.isPartitioningColumn).toBe(false);
+  });
+
+  it('marks the partitioning column in the plain array result shape', async () => {
+    const storage = columnsStorage();
+    storage.executeQuery = async () => [
+      { column_name: 'ad_id', data_type: 'STRING', is_partitioning_column: 'NO' },
+      { column_name: 'date', data_type: 'DATE', is_partitioning_column: 'YES' },
+    ];
+
+    const columns = await storage.getAListOfExistingColumns();
+
+    expect(columns.date.isPartitioningColumn).toBe(true);
+    expect(columns.ad_id.isPartitioningColumn).toBe(false);
+  });
+});
+
+describe('createTableIfItDoesntExist partitioning', () => {
+  const createStorage = schema =>
+    Object.assign(Object.create(proto), {
+      config: {
+        DestinationDatasetID: configValue('project.dataset'),
+        DestinationTableName: configValue('t'),
+        logMessage() {},
+      },
+      uniqueKeyColumns: ['id'],
+      schema,
+      getSelectedFields: () => Object.keys(schema),
+      getColumnType: column => schema[column].type,
+    });
+
+  it('partitions by the flagged DATE column and records it as table truth', async () => {
+    const storage = createStorage({
+      id: { type: 'STRING' },
+      date: { type: 'DATE', GoogleBigQueryPartitioned: true },
+    });
+    let query;
+    storage.executeQuery = async sql => {
+      query = sql;
+    };
+
+    const columns = await storage.createTableIfItDoesntExist();
+
+    expect(query).toContain('PARTITION BY date');
+    expect(columns.date.isPartitioningColumn).toBe(true);
+  });
+
+  it('emits TIMESTAMP_TRUNC DDL for a TIMESTAMP partition column', async () => {
+    const storage = createStorage({
+      id: { type: 'STRING' },
+      ts: { type: 'TIMESTAMP', GoogleBigQueryPartitioned: true },
+    });
+    let query;
+    storage.executeQuery = async sql => {
+      query = sql;
+    };
+
+    await storage.createTableIfItDoesntExist();
+
+    expect(query).toContain('PARTITION BY TIMESTAMP_TRUNC(ts, DAY)');
+  });
+
+  it('skips partitioning for a non-date flag and says so in the log', async () => {
+    const storage = createStorage({
+      id: { type: 'STRING', GoogleBigQueryPartitioned: true },
+    });
+    const messages = [];
+    storage.config.logMessage = message => messages.push(message);
+    let query;
+    storage.executeQuery = async sql => {
+      query = sql;
+    };
+
+    const columns = await storage.createTableIfItDoesntExist();
+
+    expect(query).not.toContain('PARTITION BY');
+    expect(columns.id.isPartitioningColumn).toBeUndefined();
+    expect(messages.some(m => m.includes("Column 'id'"))).toBe(true);
+  });
+});
+
+describe('formatColumnValue date handling', () => {
+  const bare = () => Object.create(proto);
+
+  it('formats a Date in a TIMESTAMP column as a UTC timestamp string', () => {
+    // Previously fell through to String(date) — a locale string that
+    // SAFE_CAST degrades to NULL, silently losing the value.
+    const value = proto.formatColumnValue.call(
+      bare(),
+      new Date('2026-08-30T10:00:00Z'),
+      'TIMESTAMP'
+    );
+
+    expect(value).toBe('2026-08-30 10:00:00');
+  });
+
+  it('recognizes cross-realm Date objects via their constructor name', () => {
+    // instanceof fails across realms (the Apps Script target); the fallback
+    // matches AbstractStorage's sibling helpers.
+    const crossRealmDate = {
+      constructor: { name: 'Date' },
+      toISOString: () => '2026-08-30T00:00:00.000Z',
+    };
+
+    const value = proto.formatColumnValue.call(bare(), crossRealmDate, 'DATE');
+
+    expect(value).toBe('2026-08-30');
+  });
+
+  it('normalizes the T separator for datetime strings in the shared helper', () => {
+    const value = proto.formatColumnValue.call(bare(), '2026-08-30T10:00:00', 'DATETIME');
+
+    expect(value).toBe('2026-08-30 10:00:00');
   });
 });

--- a/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
+++ b/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
@@ -6,6 +6,7 @@ import { loadGasClass } from '../../support/loadGasClass.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const abstractStoragePath = path.join(__dirname, '../../../src/Core/AbstractStorage.js');
+const dateUtilsPath = path.join(__dirname, '../../../src/Core/Utils/DateUtils.js');
 const storagePath = path.join(
   __dirname,
   '../../../src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js'
@@ -18,6 +19,7 @@ const storagePath = path.join(
 globalThis.require = createRequire(import.meta.url);
 
 loadGasClass(abstractStoragePath);
+loadGasClass(dateUtilsPath);
 loadGasClass(storagePath);
 const proto = globalThis.GoogleBigQueryStorage.prototype;
 
@@ -113,5 +115,166 @@ describe('getBigQueryClient', () => {
     // nobody "fixes" our passthrough expecting a refresh the library won't do;
     // acceptable in practice, since a real expiry timestamp is never 0.
     expect(authClient.isTokenExpiring()).toBe(false);
+  });
+});
+
+describe('buildMergeQuery partition pruning', () => {
+  // A report-node shaped storage: date is the partition column and part of the
+  // unique key, records span three days. Built on the real prototype so the
+  // inherited helpers (stringifyNeastedFields, obfuscateSpecialCharacters,
+  // formatColumnValue) run for real.
+  const mergeStorage = (overrides = {}) =>
+    Object.assign(Object.create(proto), {
+      config: {
+        DestinationDatasetID: configValue('project.dataset'),
+        DestinationTableName: configValue('reddit_ads_report'),
+      },
+      uniqueKeyColumns: ['ad_id', 'date'],
+      schema: {
+        ad_id: { type: 'string' },
+        date: { type: 'date', GoogleBigQueryPartitioned: true },
+        impressions: { type: 'integer' },
+      },
+      existingColumns: {
+        ad_id: { name: 'ad_id', type: 'STRING' },
+        date: { name: 'date', type: 'DATE' },
+        impressions: { name: 'impressions', type: 'INT64' },
+      },
+      updatedRecordsBuffer: {
+        'ad_1|2026-08-30': { ad_id: 'ad_1', date: new Date('2026-08-30'), impressions: 10 },
+        'ad_1|2026-08-29': { ad_id: 'ad_1', date: new Date('2026-08-29'), impressions: 7 },
+        'ad_2|2026-08-31': { ad_id: 'ad_2', date: new Date('2026-08-31'), impressions: 3 },
+      },
+      ...overrides,
+    });
+
+  const bufferKeys = storage => Object.keys(storage.updatedRecordsBuffer);
+
+  it('bounds the target to the batch date range so BigQuery can prune partitions', () => {
+    const storage = mergeStorage();
+
+    const query = storage.buildMergeQuery(bufferKeys(storage));
+
+    expect(query).toContain("AND target.date BETWEEN DATE '2026-08-29' AND DATE '2026-08-31'");
+  });
+
+  it('keeps the unique-key join conditions unchanged next to the range predicate', () => {
+    const storage = mergeStorage();
+
+    const query = storage.buildMergeQuery(bufferKeys(storage));
+
+    expect(query).toContain('target.ad_id = source.ad_id');
+    expect(query).toContain('target.date = source.date');
+  });
+
+  it('emits no predicate for entity nodes whose schema declares no partition column', () => {
+    // The `ads` node regression guard: uniqueKeys ["id"], no date field at all.
+    const storage = mergeStorage({
+      uniqueKeyColumns: ['id'],
+      schema: { id: { type: 'string' }, name: { type: 'string' } },
+      existingColumns: {
+        id: { name: 'id', type: 'STRING' },
+        name: { name: 'name', type: 'STRING' },
+      },
+      updatedRecordsBuffer: { ad_1: { id: 'ad_1', name: 'Ad One' } },
+    });
+
+    const query = storage.buildMergeQuery(bufferKeys(storage));
+
+    expect(query).not.toContain('BETWEEN');
+    expect(query).toContain('ON target.id = source.id');
+  });
+
+  it('suppresses the predicate when any record lacks a partition value', () => {
+    // A predicate that misses one record's partition would silently drop that
+    // record's update, so one gap disables pruning for the whole batch.
+    const storage = mergeStorage();
+    storage.updatedRecordsBuffer['ad_1|2026-08-30'].date = null;
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBeNull();
+  });
+
+  it('suppresses the predicate when the partition column is not part of the unique key', () => {
+    // Without `target.date = source.date` in the ON clause, bounding the
+    // target's date would hide matching rows in out-of-range partitions and
+    // the MERGE would insert duplicates instead of updating them.
+    const storage = mergeStorage({ uniqueKeyColumns: ['ad_id'] });
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBeNull();
+  });
+
+  it('suppresses the predicate when the destination table predates the partition flag', () => {
+    const storage = mergeStorage({
+      existingColumns: {
+        ad_id: { name: 'ad_id', type: 'STRING' },
+        impressions: { name: 'impressions', type: 'INT64' },
+      },
+    });
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBeNull();
+  });
+
+  it('suppresses the predicate when a value does not look like a date literal', () => {
+    // Values come from vendor APIs; anything that could escape the quoted
+    // literal (or is plain garbage) must disable pruning, not corrupt the SQL.
+    const storage = mergeStorage();
+    storage.updatedRecordsBuffer['ad_1|2026-08-30'].date = "2026-08-30' OR '1'='1";
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBeNull();
+  });
+
+  it('suppresses the predicate for zone-bearing timestamps, whose string order is not time order', () => {
+    // '2026-08-30 23:00:00+10:00' is 13:00 UTC — lexicographically the max of
+    // this batch but chronologically its min. A range built from string
+    // comparison would exclude the 14:00Z row and duplicate it on merge.
+    const storage = mergeStorage({
+      existingColumns: {
+        ad_id: { name: 'ad_id', type: 'STRING' },
+        date: { name: 'date', type: 'TIMESTAMP' },
+        impressions: { name: 'impressions', type: 'INT64' },
+      },
+      updatedRecordsBuffer: {
+        a: { ad_id: 'ad_1', date: '2026-08-30 14:00:00Z', impressions: 1 },
+        b: { ad_id: 'ad_2', date: '2026-08-30 23:00:00+10:00', impressions: 2 },
+      },
+    });
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBeNull();
+  });
+
+  it('normalizes the T separator so ISO-style datetimes still produce a predicate', () => {
+    const storage = mergeStorage({
+      existingColumns: {
+        ad_id: { name: 'ad_id', type: 'STRING' },
+        date: { name: 'date', type: 'DATETIME' },
+        impressions: { name: 'impressions', type: 'INT64' },
+      },
+      updatedRecordsBuffer: {
+        a: { ad_id: 'ad_1', date: '2026-08-30T10:00:00', impressions: 1 },
+        b: { ad_id: 'ad_2', date: '2026-08-31 09:30:00', impressions: 2 },
+      },
+    });
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBe(
+      "target.date BETWEEN DATETIME '2026-08-30 10:00:00' AND DATETIME '2026-08-31 09:30:00'"
+    );
+  });
+
+  it('uses a TIMESTAMP literal for a TIMESTAMP partition column', () => {
+    const storage = mergeStorage({
+      existingColumns: {
+        ad_id: { name: 'ad_id', type: 'STRING' },
+        date: { name: 'date', type: 'TIMESTAMP' },
+        impressions: { name: 'impressions', type: 'INT64' },
+      },
+      updatedRecordsBuffer: {
+        a: { ad_id: 'ad_1', date: '2026-08-30 10:00:00', impressions: 1 },
+        b: { ad_id: 'ad_2', date: '2026-08-31 09:30:00', impressions: 2 },
+      },
+    });
+
+    expect(storage.buildPartitionPredicate(bufferKeys(storage))).toBe(
+      "target.date BETWEEN TIMESTAMP '2026-08-30 10:00:00' AND TIMESTAMP '2026-08-31 09:30:00'"
+    );
   });
 });


### PR DESCRIPTION
# Problem

Every incremental connector run into Google BigQuery merged new records with an `ON` clause containing only unique-key equality conditions (`target.date = source.date`). BigQuery cannot prune partitions from a join predicate against a subquery of literals — pruning requires a constant filter on the target column — so every MERGE scanned the entire destination table to write a few days of data. Scan cost therefore grew with table history rather than with imported volume, and long-lived time-series tables (ad performance reports) eventually exhausted per-user daily quotas: a client's scheduled RedditAds run failed with `Custom quota exceeded: QueryUsagePerUserPerDay`. Measured on a synthetic 600-partition table, the current query shape processes 1.16 GB where a pruned one processes 3.89 MB (~99.7% reduction).

# Solution

Derive a constant date-range filter from the batch being merged and append it to the MERGE `ON` clause: `AND target.date BETWEEN DATE '…' AND DATE '…'`. The addition is semantically neutral whenever the partition column is part of the unique key, because `target.date = source.date` already restricts matches to the batch's dates — the literal range only restates that fact in a form the query planner can act on.

The partition column comes from the **destination table itself**, not from the schema: `getAListOfExistingColumns()` now reads `is_partitioning_column` from `INFORMATION_SCHEMA.COLUMNS`, and `createTableIfItDoesntExist()` records which column it actually emitted `PARTITION BY` for. The `GoogleBigQueryPartitioned` schema flag only drives table creation (unchanged last-wins selection when several fields carry it). This matters in practice: LinkedIn Ads flags both `dateRangeStart` and `dateRangeEnd`, so schema inference would have filtered a different column than existing tables are partitioned by, producing a valid predicate that prunes nothing.

Safety is guard-based: the predicate is emitted only when every condition holds, and any ambiguity falls back to the existing full-scan behavior (slow but always correct). Guards cover:

- the destination table has no partitioning column — entity nodes like `ads` and `campaigns`, legacy unpartitioned tables — SQL unchanged
- the partitioning column is not in `uniqueKeyColumns` — without the matching equality condition, a bounded scan would hide matching target rows in out-of-range partitions and the MERGE would insert duplicates (an audit of all 15 sources found one live instance: OpenHolidays flags `date` but keys on `id`)
- the column type is not `DATE`/`DATETIME`/`TIMESTAMP`
- any record missing its partition value
- any value not matching one canonical fixed-width shape per type (fractions, `Z`, and zone offsets rejected; `T`/space separators normalized) — min/max is computed by string comparison, which equals chronological order only for uniform fixed-width values; this also blocks quote-shaped input from reaching the SQL literal
- any value that is shape-valid but not a real calendar date/time (`2026-02-31`, `25:00:00`) — a typed literal would fail the whole query, where `SAFE_CAST` in source rows degrades the same input to `NULL`

Value formatting is shared with the source-row builder via an extracted `formatColumnValue()`, so predicate literals can never diverge from the row values they bound. Chunked batches (`executeMergeQueryRecursively`) each compute their own, tighter range. Table-creation DDL is fixed alongside: `DATETIME`/`TIMESTAMP` partition columns now emit valid `_TRUNC(col, DAY)` expressions (the bare-column form is invalid DDL for those types; dormant today since every flagged field repo-wide is `DATE`-typed). Other MERGE storages (Snowflake, Redshift, Databricks) are out of scope — they have no partition metadata flag and different billing models.

# Changes

- Added `buildPartitionPredicate()` to `GoogleBigQueryStorage` and wired it into the MERGE `ON` clause
- Added `is_partitioning_column` to the `INFORMATION_SCHEMA.COLUMNS` query and both result-parsing branches; `createTableIfItDoesntExist()` records the emitted partition column the same way, so same-run create-then-merge flows also prune
- Added `buildPartitionByExpression()`: `DATE` partitions by bare column, `DATETIME`/`TIMESTAMP` by `_TRUNC(col, DAY)`, unsupported types skip `PARTITION BY` instead of emitting invalid SQL
- Added `isRealCalendarValue()` semantic validation on top of the shape regexes
- Extracted value normalization from `buildMergeQuery()` into `formatColumnValue()`, shared by row building and the predicate
- Normalized `T`/space datetime separators before validation and comparison
- Added 13 tests covering the emitted range, entity-node passthrough, guard suppressions (missing value, unpartitioned table, non-unique-key partition column, zone-bearing timestamps, injection-shaped values, impossible calendar dates, out-of-range times), TIMESTAMP literals, table-truth-vs-schema mismatch (LinkedIn case), and unchanged unique-key conditions
- Documented the `GoogleBigQueryPartitioned` contract in `CREATING_CONNECTOR.md`: date-like type required (`_TRUNC` daily granularity for `DATETIME`/`TIMESTAMP`), field must be in `uniqueKeys`, flag exactly one field per node
- Added changeset `6880-bq-merge-partition-pruning.md` (`'owox': minor`)