### PR TITLE
fix(web): open OWOX BI from the project menu in the current project

### DIFF
--- a/.changeset/6897-owox-bi-project-menu-link.md
+++ b/.changeset/6897-owox-bi-project-menu-link.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+The OWOX BI link in the project menu now opens the current project in BI instead of the BI home page.
+
+When you are in a Data Marts project and choose OWOX BI from the project menu, you land in that same project on bi.owox.com.

--- a/apps/web/src/components/AppSidebar/ProjectMenu/items.ts
+++ b/apps/web/src/components/AppSidebar/ProjectMenu/items.ts
@@ -55,6 +55,7 @@ export const projectMenuItems: ProjectMenuItem[] = [
     type: 'menu-item',
     title: 'OWOX BI',
     href: 'https://bi.owox.com/',
+    buildHref: projectId => `https://bi.owox.com/ui/app/${projectId}`,
     icon: OWOXBIIcon,
     visible: { flagKey: 'MENU_OWOX_BI_VISIBLE', expectedValue: 'true' },
     group: 'external',

--- a/apps/web/src/components/AppSidebar/ProjectMenu/types.ts
+++ b/apps/web/src/components/AppSidebar/ProjectMenu/types.ts
@@ -11,6 +11,8 @@ export interface ProjectMenuItem {
   type: 'menu-item' | 'separator' | 'project-settings-submenu';
   title: string;
   href: string;
+  /** Builds a project-scoped external URL when the current project id is known. */
+  buildHref?: (projectId: string) => string;
   icon: React.ComponentType<{ className?: string }>;
   visible: VisibilityConfig;
   group: string;

--- a/apps/web/src/components/AppSidebar/ProjectMenu/useProjectMenu.test.ts
+++ b/apps/web/src/components/AppSidebar/ProjectMenu/useProjectMenu.test.ts
@@ -15,7 +15,7 @@ const flagsState = vi.hoisted(() => ({
     flags: {
       MENU_OWOX_BI_VISIBLE: 'true',
     } as Record<string, unknown>,
-    callState: 'success' as RequestStatus,
+    callState: 'loaded' as RequestStatus,
   },
 }));
 

--- a/apps/web/src/components/AppSidebar/ProjectMenu/useProjectMenu.test.ts
+++ b/apps/web/src/components/AppSidebar/ProjectMenu/useProjectMenu.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestStatus } from '../../../shared/types/request-status.ts';
+import { useProjectMenu } from './useProjectMenu';
+
+const projectState = vi.hoisted(() => ({
+  value: {
+    id: '2efa3556b1d5bec2f99b6fca4c0010db' as string | null,
+    title: 'Demo project' as string | null,
+  },
+}));
+
+const flagsState = vi.hoisted(() => ({
+  value: {
+    flags: {
+      MENU_OWOX_BI_VISIBLE: 'true',
+    } as Record<string, unknown>,
+    callState: 'success' as RequestStatus,
+  },
+}));
+
+vi.mock('../../../app/store/hooks', () => ({
+  useProject: () => projectState.value,
+  useFlags: () => flagsState.value,
+}));
+
+vi.mock('../../../features/idp/hooks/useProjects.ts', () => ({
+  useProjects: () => ({
+    projects: [],
+    loadProjects: vi.fn(),
+    callState: 'idle',
+    error: null,
+    isLoading: false,
+    reset: vi.fn(),
+  }),
+}));
+
+function getOwoxBiHref() {
+  const { result } = renderHook(() => useProjectMenu());
+  const owoxBiItem = result.current.visibleMenuItems.find(
+    item => item.type === 'menu-item' && item.title === 'OWOX BI'
+  );
+
+  return owoxBiItem && 'href' in owoxBiItem ? owoxBiItem.href : undefined;
+}
+
+describe('useProjectMenu', () => {
+  beforeEach(() => {
+    projectState.value = {
+      id: '2efa3556b1d5bec2f99b6fca4c0010db',
+      title: 'Demo project',
+    };
+  });
+
+  it('opens OWOX BI in the current project instead of the BI root', () => {
+    expect(getOwoxBiHref()).toBe('https://bi.owox.com/ui/app/2efa3556b1d5bec2f99b6fca4c0010db');
+  });
+
+  it('falls back to the BI root when the current project is unknown', () => {
+    projectState.value = { id: null, title: null };
+
+    expect(getOwoxBiHref()).toBe('https://bi.owox.com/');
+  });
+});

--- a/apps/web/src/components/AppSidebar/ProjectMenu/useProjectMenu.ts
+++ b/apps/web/src/components/AppSidebar/ProjectMenu/useProjectMenu.ts
@@ -32,6 +32,10 @@ export function useProjectMenu() {
     });
 
     const mappedItems = filteredItems.map(item => {
+      if (id && item.buildHref) {
+        return { ...item, href: item.buildHref(id) } as ProjectMenuItem;
+      }
+
       if (item.group === 'project' && item.href && id) {
         try {
           const updatedHref = item.href.replace('/p/none/', `/p/${id}/`);


### PR DESCRIPTION
## Problem

The project menu **OWOX BI** item always opened the BI root (`https://bi.owox.com/`), even though ODM and OWOX BI share the same project id.

## Expected

When the user is in an ODM project, the menu item should open that same project in BI.

Example:

- ODM: https://app.owox.com/ui/2efa3556b1d5bec2f99b6fca4c0010db
- OWOX BI: https://bi.owox.com/ui/app/2efa3556b1d5bec2f99b6fca4c0010db

If the current project id is unknown, the link still opens `https://bi.owox.com/`.

## Fix

- Add optional `buildHref` on project menu items
- Resolve the OWOX BI href in `useProjectMenu` from `useProject().id`
- Keep the existing static href as the fallback

## Testing

- Hook tests cover the project-scoped URL and the root fallback
- `npm test -w @owox/web -- src/components/AppSidebar/ProjectMenu`
- ESLint, Prettier, and `tsc --noEmit` for `@owox/web`