### PR TITLE
feat(backend): link the Google Sheets header note to the report

### DIFF
--- a/.changeset/6898-sheets-note-report-link.md
+++ b/.changeset/6898-sheets-note-report-link.md
@@ -2,6 +2,8 @@
 'owox': minor
 ---
 
-Link the Google Sheets header note to the report instead of the Data Mart
+# Google Sheets column notes link to the report, not to the Data Mart
 
-The provenance note on the first imported column now ends with **Report page** and a link that opens the report itself — the Reports tab with that report's panel already expanded — instead of the Data Mart setup tab. That note is the only in-sheet trace of where the data came from, and it is usually opened when a sheet has stopped refreshing, so it now lands on the report whose schedule and run history explain what happened, rather than leaving you to find it among all the reports of that Data Mart. The Data Mart name stays on its own line above the link.
+The provenance block in an imported column's note now ends with **Report page** and a link that opens the report itself — the Reports tab with that report's panel already expanded — instead of the Data Mart setup tab.
+
+That note is the only in-sheet trace of where the data came from, and it is usually opened when a sheet has stopped refreshing. It now lands on the report whose schedule and run history explain what happened, rather than leaving you to find it among all the reports of that Data Mart. The Data Mart name stays on its own line above the link.

--- a/.changeset/6898-sheets-note-report-link.md
+++ b/.changeset/6898-sheets-note-report-link.md
@@ -2,8 +2,10 @@
 'owox': minor
 ---
 
-# Google Sheets column notes link to the report, not to the Data Mart
+# Report links point at the report, not at the Data Mart
 
-The provenance block in an imported column's note now ends with **Report page** and a link that opens the report itself — the Reports tab with that report's panel already expanded — instead of the Data Mart setup tab.
+The provenance block in a Google Sheets imported column's note now ends with **Report page** and a link that opens the report itself — the Reports tab with that report's panel already expanded — instead of the Data Mart setup tab.
 
 That note is the only in-sheet trace of where the data came from, and it is usually opened when a sheet has stopped refreshing. It now lands on the report whose schedule and run history explain what happened, rather than leaving you to find it among all the reports of that Data Mart. The Data Mart name stays on its own line above the link.
+
+The **Open report in OWOX Data Marts** button on a Google Chat report card and the **Edit report** link in a report email footer now open the same deep link. Both previously landed on the Data Mart's report list, leaving the reader to pick the right report out of it.

--- a/.changeset/6898-sheets-note-report-link.md
+++ b/.changeset/6898-sheets-note-report-link.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+Link the Google Sheets header note to the report instead of the Data Mart
+
+The provenance note on the first imported column now ends with **Report page** and a link that opens the report itself — the Reports tab with that report's panel already expanded — instead of the Data Mart setup tab. That note is the only in-sheet trace of where the data came from, and it is usually opened when a sheet has stopped refreshing, so it now lands on the report whose schedule and run history explain what happened, rather than leaving you to find it among all the reports of that Data Mart. The Data Mart name stays on its own line above the link.

--- a/apps/backend/src/common/helpers/data-mart-url.helper.ts
+++ b/apps/backend/src/common/helpers/data-mart-url.helper.ts
@@ -41,3 +41,35 @@ export function buildDataMartUrl(
 
   return `${normalizedBaseUrl}/ui/${projectId}/data-marts`;
 }
+
+/**
+ * Query parameter the web UI reads to open a report's sidesheet on the
+ * Data Mart Reports tab. Kept in sync with `REPORT_ID_URL_PARAM` in
+ * `apps/web` — the deep link behind the report sidesheet's "Copy link".
+ */
+const REPORT_ID_URL_PARAM = 'reportId';
+
+/**
+ * Builds a deep link that opens the Data Mart Reports tab with the given
+ * report's sidesheet already expanded — the same link the report sidesheet
+ * offers under "Copy link".
+ *
+ * @param baseUrl - The base URL (e.g., https://example.com or http://localhost:3000)
+ * @param projectId - The project ID
+ * @param dataMartId - The ID of the Data Mart the report belongs to
+ * @param reportId - The report ID
+ * @returns The complete URL
+ *
+ * @example
+ * buildReportUrl('https://example.com', 'proj-123', 'dm-456', 'rep-789')
+ * // Returns: 'https://example.com/ui/proj-123/data-marts/dm-456/reports?reportId=rep-789'
+ */
+export function buildReportUrl(
+  baseUrl: string,
+  projectId: string,
+  dataMartId: string,
+  reportId: string
+): string {
+  const reportsUrl = buildDataMartUrl(baseUrl, projectId, dataMartId, '/reports');
+  return `${reportsUrl}?${REPORT_ID_URL_PARAM}=${encodeURIComponent(reportId)}`;
+}

--- a/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.ts
@@ -369,6 +369,7 @@ export abstract class BaseEmailReportWriter implements DataDestinationReportWrit
       dataMartId: this.report.dataMart.id,
       dataMartTitle: this.report.dataMart.title,
       projectId: this.report.dataMart.projectId,
+      reportId: this.report.id,
       reportBody: reportHtml,
       publicOrigin: this.publicOriginService.getPublicOrigin(),
     });

--- a/apps/backend/src/data-marts/data-destination-types/ee/email/templates/email-report.template.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/templates/email-report.template.ts
@@ -1,9 +1,10 @@
-import { buildDataMartUrl } from '../../../../../common/helpers/data-mart-url.helper';
+import { buildReportUrl } from '../../../../../common/helpers/data-mart-url.helper';
 
 export interface EmailReportTemplateProps {
   reportBody: string;
   dataMartTitle: string;
   dataMartId: string;
+  reportId: string;
   projectId: string;
   publicOrigin: string;
 }
@@ -19,6 +20,7 @@ export interface EmailReportTemplateProps {
  * @param {string} props.dataMartTitle - The title of the data mart displayed in the footer of the email.
  * @param {string} props.projectId - The project ID used to generate URLs for editing the report.
  * @param {string} props.dataMartId - The data mart ID used to generate URLs for editing the report.
+ * @param {string} props.reportId - The report ID, so the "Edit report" link opens this report rather than the report list.
  * @return {string} The rendered email report HTML as a string.
  */
 export function renderEmailReportTemplate(props: EmailReportTemplateProps): string {
@@ -87,7 +89,7 @@ export function renderEmailReportTemplate(props: EmailReportTemplateProps): stri
                     ${props.dataMartTitle}
                   </td>
                   <td style="vertical-align:middle;text-align:right;font-size:13px;color:#6b7280;">
-                    <a href="${buildDataMartUrl(props.publicOrigin, props.projectId, props.dataMartId, '/reports')}" target="_blank" rel="noopener noreferrer" style="color:#1E88E5;text-decoration:none;">Edit report</a>
+                    <a href="${buildReportUrl(props.publicOrigin, props.projectId, props.dataMartId, props.reportId)}" target="_blank" rel="noopener noreferrer" style="color:#1E88E5;text-decoration:none;">Edit report</a>
                   </td>
                 </tr>
               </table>

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
@@ -98,8 +98,9 @@ describe('GoogleChatReportWriter', () => {
       textSyntax: 'MARKDOWN',
     });
     expect(payload.fallbackText).toBe('Weekly report — Data Mart: Sales');
+    // The card link opens this report's own panel, not the Data Mart's report list.
     expect(JSON.stringify(payload)).toContain(
-      'https://example.test/ui/project-1/data-marts/data-mart-1/reports'
+      'https://example.test/ui/project-1/data-marts/data-mart-1/reports?reportId=report-1'
     );
     expect(eventDispatcher.publishExternal.mock.calls[0][0].name).toBe(
       'google-chat.report.run.successfully'

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../../../common/email/shared/email-provider.facade';
 import { OwoxEventDispatcher } from '../../../../../common/event-dispatcher/owox-event-dispatcher';
 import { MarkdownParser } from '../../../../../common/markdown/markdown-parser.service';
-import { buildDataMartUrl } from '../../../../../common/helpers/data-mart-url.helper';
+import { buildReportUrl } from '../../../../../common/helpers/data-mart-url.helper';
 import { DataMartInsightTemplateFacadeImpl } from '../../../../ai-insights/data-mart-insight-template.facade';
 import { Report } from '../../../../entities/report.entity';
 import { InsightTemplateSourceDataService } from '../../../../services/insight-template-source-data.service';
@@ -340,11 +340,11 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
       throw new Error('Google Chat webhook credentials are not configured');
     }
 
-    const reportUrl = buildDataMartUrl(
+    const reportUrl = buildReportUrl(
       this.chatPublicOriginService.getPublicOrigin(),
       this.report.dataMart.projectId,
       this.report.dataMart.id,
-      '/reports'
+      this.report.id
     );
     const messages = buildGoogleChatMessages({
       subject: this.emailConfig.subject,

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -916,6 +916,24 @@ describe('GoogleSheetsReportWriter — per-column header notes', () => {
     );
   });
 
+  it('links the A1 note to the report deep link, not to the data mart page', async () => {
+    const { writer, report, finalImportedNames, metadataFormatter } = buildWriter({
+      availableRowsCount: 11,
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+    await writer.finalize();
+
+    // The note is read when a sheet stops refreshing, so it must land on the
+    // report itself rather than on the data mart's setup tab.
+    const urlArg = metadataFormatter.buildImportedColumnNote.mock.calls[0][2] as string;
+    expect(urlArg).toBe('https://example.test/ui/proj-1/data-marts/dm-1/reports?reportId=report-1');
+  });
+
   it('does not write the full A1 note when the reader fails before any batch', async () => {
     const { writer, report, finalImportedNames, metadataFormatter } = buildWriter({
       availableRowsCount: 11,

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -30,7 +30,7 @@ import {
 import { BusinessViolationException } from 'src/common/exceptions/business-violation.exception';
 import { AppEditionConfig } from '../../../../common/config/app-edition-config.service';
 import { PublicOriginService } from '../../../../common/config/public-origin.service';
-import { buildDataMartUrl } from '../../../../common/helpers/data-mart-url.helper';
+import { buildReportUrl } from '../../../../common/helpers/data-mart-url.helper';
 
 /**
  * Service for writing report data to Google Sheets
@@ -575,23 +575,26 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
         //
         // `dataMart` is always the main/home data mart — columns pulled in from
         // joinable data marts only change the column alias, never this note — so
-        // A1 references the original data mart even for blended marts.
+        // A1 references the original data mart even for blended marts. The link
+        // itself points at this report rather than at the data mart: the note is
+        // read when a sheet stops refreshing, and the report is what has to be
+        // inspected then.
         const firstColumnName = this.columnPlan.finalImportedNames[0];
         const firstColumnHeader = this.headersByName.get(firstColumnName);
         const dateFinished = DateTime.now().setZone(this.spreadsheetTimeZone);
         const dateFinishedFormatted = `${dateFinished.toFormat('yyyy LLL d, HH:mm:ss')} ${dateFinished.zoneName}`;
         const isCommunityEdition = !this.appEditionConfig.isEnterpriseEdition();
         const publicOrigin = this.publicOriginService.getPublicOrigin();
-        const dataMartUrl = buildDataMartUrl(
+        const reportUrl = buildReportUrl(
           publicOrigin,
           dataMart.projectId,
           dataMart.id,
-          '/data-setup'
+          this.report.id
         );
         const a1Note = this.metadataFormatter.buildImportedColumnNote(
           firstColumnHeader?.description,
           this.dataMartTitle,
-          dataMartUrl,
+          reportUrl,
           dateFinishedFormatted,
           isCommunityEdition
         );

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.spec.ts
@@ -145,7 +145,7 @@ describe('SheetMetadataFormatter', () => {
   describe('buildImportedColumnNote', () => {
     const baseArgs = {
       title: 'Test Data Mart',
-      url: 'https://app.owox.com/ui/proj-1/dm-2',
+      url: 'https://app.owox.com/ui/proj-1/data-marts/dm-2/reports?reportId=rep-3',
       date: '2026-04-02 12:00:00 UTC',
     };
 
@@ -165,7 +165,7 @@ describe('SheetMetadataFormatter', () => {
       expect(note).toContain('\n\n--- Imported via OWOX Data Marts ---\n');
       expect(note).toContain('Imported at 2026-04-02 12:00:00 UTC');
       expect(note).toContain(`Data Mart: ${baseArgs.title}`);
-      expect(note).toContain(`Data Mart page: ${baseArgs.url}`);
+      expect(note).toContain(`Report page: ${baseArgs.url}`);
       expect(note.indexOf('Imported at')).toBeGreaterThan(note.indexOf('---'));
     });
 

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
@@ -216,14 +216,16 @@ export class SheetMetadataFormatter {
    * The column's own description is placed first (so users see the relevant
    * context immediately), separated by a blank line from the ODM provenance
    * block — marker line, import date, data mart title, and link back to the
-   * OWOX UI. If the description is empty or exceeds
-   * {@link MAX_DESCRIPTION_LENGTH_IN_NOTE} characters, it is omitted or
-   * truncated with an ellipsis to stay within Sheets' note size limit.
+   * OWOX UI. The link points at the *report* that wrote the range rather than
+   * at its data mart: the note is read when a sheet stops refreshing, and the
+   * report is what has to be inspected then. If the description is empty or
+   * exceeds {@link MAX_DESCRIPTION_LENGTH_IN_NOTE} characters, it is omitted
+   * or truncated with an ellipsis to stay within Sheets' note size limit.
    */
   public buildImportedColumnNote(
     description: string | undefined,
     dataMartTitle: string,
-    dataMartUrl: string,
+    reportUrl: string,
     dateFormatted: string,
     isCommunityEdition: boolean
   ): string {
@@ -231,7 +233,7 @@ export class SheetMetadataFormatter {
       `${this.buildOdmMarker(isCommunityEdition)}\n` +
       `Imported at ${dateFormatted}\n` +
       `Data Mart: ${dataMartTitle}\n` +
-      `Data Mart page: ${dataMartUrl}`;
+      `Report page: ${reportUrl}`;
     return this.assembleColumnNote(description, odmInfo);
   }
 

--- a/docs/destinations/supported-destinations/google-sheets.md
+++ b/docs/destinations/supported-destinations/google-sheets.md
@@ -180,9 +180,13 @@ successful run replaces it.
 ### Per-column header notes
 
 Each imported column header carries a note (hover the cell in Google Sheets
-to view it). The note begins with the column's Output Schema description (if
-one is set) followed by a provenance block: the data mart name, a link to the
-report that keeps the sheet up to date, and the timestamp of the latest
-refresh. Use these notes to confirm the source and freshness of any column at
-a glance; the link opens that report in OWOX Data Marts, which is where you
-check its schedule or its run history when the sheet stops updating.
+to view it). Every note starts with the column's Output Schema description
+(if one is set), followed by the `--- Imported via OWOX Data Marts ---`
+marker that tells you the column is kept up to date by OWOX.
+
+The **first column of the imported range** carries a full provenance block
+instead of the bare marker: the data mart name, the timestamp of the latest
+refresh, and a link to the report that writes the range. Hover that one cell
+to confirm the source and freshness of the whole range, or to open the report
+in OWOX Data Marts — that is where you check its schedule and run history when
+the sheet stops updating.

--- a/docs/destinations/supported-destinations/google-sheets.md
+++ b/docs/destinations/supported-destinations/google-sheets.md
@@ -181,6 +181,8 @@ successful run replaces it.
 
 Each imported column header carries a note (hover the cell in Google Sheets
 to view it). The note begins with the column's Output Schema description (if
-one is set) followed by a provenance block: the data mart name, a link to
-it in OWOX Data Marts, and the timestamp of the latest refresh. Use these
-notes to confirm the source and freshness of any column at a glance.
+one is set) followed by a provenance block: the data mart name, a link to the
+report that keeps the sheet up to date, and the timestamp of the latest
+refresh. Use these notes to confirm the source and freshness of any column at
+a glance; the link opens that report in OWOX Data Marts, which is where you
+check its schedule or its run history when the sheet stops updating.


### PR DESCRIPTION
## What

The provenance note ODM writes into the first imported column of a Google Sheets report (A1 of the imported range) ended with a link to the Data Mart's **data-setup** tab:

```
--- Imported via OWOX Data Marts ---
Imported at 2026 Apr 7, 15:00:26 Etc/GMT
Data Mart: User Acquisition
Data Mart page: https://app.owox.com/ui/<project>/data-marts/<dm>/data-setup
```

It now links to the report that keeps the sheet up to date:

```
--- Imported via OWOX Data Marts ---
Imported at 2026 Apr 7, 15:00:26 Etc/GMT
Data Mart: User Acquisition
Report page: https://app.owox.com/ui/<project>/data-marts/<dm>/reports?reportId=<report>
```

## Why

That note is the only in-sheet trace of where the data came from, so it is opened exactly when something looks wrong — most often when the sheet has stopped refreshing. The Data Mart link did not answer that: it landed on the setup tab, from where the user still had to find the right report among all reports of that Data Mart. The report deep link opens the Reports tab with that report's panel already expanded, next to its schedule and run history.

## Changes

- `buildReportUrl` added next to `buildDataMartUrl`; it composes the same deep link the report sidesheet offers under **Copy link**.
- `GoogleSheetsReportWriter` passes the report URL into the A1 note.
- `SheetMetadataFormatter` renames the line to `Report page:`; the `Data Mart:` title line is unchanged, and short per-column markers are untouched.
- Docs and a changeset updated.

Blended reports are unaffected in behaviour: the note has always referenced the main/home Data Mart, and the report it links to belongs to that Data Mart.

## Verification

- `npm run build -w @owox/backend`
- `npm test -w @owox/backend -- sheet-metadata-formatter google-sheets-report-writer` — 58 passed, including a new assertion that the A1 note carries the report deep link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)