### PR TITLE
feat(shopify): add checkoutToken field to orders

### DIFF
--- a/.changeset/6883-shopify-order-checkout-token.md
+++ b/.changeset/6883-shopify-order-checkout-token.md
@@ -2,6 +2,6 @@
 'owox': minor
 ---
 
-# Checkout token for Shopify orders
+# Checkout and cart tokens for Shopify orders
 
-The Shopify connector now offers a `checkoutToken` field on the `orders` node. Add `orders checkoutToken` to the Fields list to import it. The value matches `checkout.token` in Shopify Web Pixel events, so you can join orders with `checkout_completed` events. Orders that did not originate from a checkout, such as orders created through the API, have no token and return NULL.
+The Shopify connector now offers `checkoutToken` and `cartToken` fields on the `orders` node. Select them under `orders` in the connector's field picker to import them. `checkoutToken` matches `checkout.token` in Shopify Web Pixel events, so you can join orders with `checkout_completed` events; `cartToken` identifies the cart that produced the order. Orders with no associated checkout or cart return NULL. Orders imported before you enable the fields stay NULL until you re-import them with a backfill run.

--- a/.changeset/6883-shopify-order-checkout-token.md
+++ b/.changeset/6883-shopify-order-checkout-token.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Checkout token for Shopify orders
+
+The Shopify connector now offers a `checkoutToken` field on the `orders` node. Add `orders checkoutToken` to the Fields list to import it. The value matches `checkout.token` in Shopify Web Pixel events, so you can join orders with `checkout_completed` events. Orders that did not originate from a checkout, such as orders created through the API, have no token and return NULL.

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/ordersFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/ordersFields.js
@@ -194,9 +194,14 @@ var ordersFields = {
     'graphqlPath': 'sourceName'
   },
   'checkoutToken': {
-    'description': 'Token of the checkout that created the order. Matches checkout.token in Web Pixel events. Null when the order did not originate from a checkout, for example orders created through the API.',
+    'description': 'Token of the checkout that created the order. Useful for correlating the order with Web Pixel checkout events. NULL when no checkout is associated.',
     'type': DATA_TYPES.STRING,
     'graphqlPath': 'checkoutToken'
+  },
+  'cartToken': {
+    'description': 'Token of the cart that was used to create the order. NULL when no cart is associated.',
+    'type': DATA_TYPES.STRING,
+    'graphqlPath': 'cartToken'
   },
   'processedAt': {
     'description': 'The date and time when the order was processed.',

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/ordersFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/ordersFields.js
@@ -193,6 +193,11 @@ var ordersFields = {
     'type': DATA_TYPES.STRING,
     'graphqlPath': 'sourceName'
   },
+  'checkoutToken': {
+    'description': 'Token of the checkout that created the order. Matches checkout.token in Web Pixel events. Null when the order did not originate from a checkout, for example orders created through the API.',
+    'type': DATA_TYPES.STRING,
+    'graphqlPath': 'checkoutToken'
+  },
   'processedAt': {
     'description': 'The date and time when the order was processed.',
     'type': DATA_TYPES.TIMESTAMP,

--- a/packages/connectors/test/Sources/Shopify/Source.test.js
+++ b/packages/connectors/test/Sources/Shopify/Source.test.js
@@ -16,22 +16,27 @@ loadGasClass(src('Sources/Shopify/Source.js'));
 const proto = globalThis.ShopifySource.prototype;
 const schema = { fields: globalThis.ordersFields };
 
-describe('orders checkoutToken', () => {
-  it('requests checkoutToken as a bare scalar', () => {
-    expect(proto._buildQueryFields.call(proto, schema, ['id', 'checkoutToken'])).toBe(
-      'id checkoutToken'
+describe('orders checkoutToken and cartToken', () => {
+  it('requests both tokens as bare scalars', () => {
+    expect(proto._buildQueryFields.call(proto, schema, ['id', 'checkoutToken', 'cartToken'])).toBe(
+      'id checkoutToken cartToken'
     );
   });
 
-  it('maps checkoutToken from the order node', () => {
-    const node = { id: 'gid://shopify/Order/1', checkoutToken: 'a1b2c3d4' };
+  it('maps both tokens from the order node', () => {
+    const node = { id: 'gid://shopify/Order/1', checkoutToken: 'a1b2c3d4', cartToken: 'e5f6a7b8' };
     expect(
-      proto._normalizeFromSchema.call(proto, { node, schema, fields: ['id', 'checkoutToken'] })
-    ).toEqual({ id: 'gid://shopify/Order/1', checkoutToken: 'a1b2c3d4' });
+      proto._normalizeFromSchema.call(proto, {
+        node,
+        schema,
+        fields: ['id', 'checkoutToken', 'cartToken'],
+      })
+    ).toEqual({ id: 'gid://shopify/Order/1', checkoutToken: 'a1b2c3d4', cartToken: 'e5f6a7b8' });
   });
 
-  it('yields null when the order has no checkout token', () => {
-    const node = { id: 'gid://shopify/Order/2', checkoutToken: null };
+  it('yields null when the node omits checkoutToken', () => {
+    // Key absent (not null): exercises the undefined -> _formatValue -> null path.
+    const node = { id: 'gid://shopify/Order/2' };
     expect(
       proto._normalizeFromSchema.call(proto, { node, schema, fields: ['checkoutToken'] })
     ).toEqual({ checkoutToken: null });

--- a/packages/connectors/test/Sources/Shopify/Source.test.js
+++ b/packages/connectors/test/Sources/Shopify/Source.test.js
@@ -1,0 +1,39 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const src = (...p) => path.join(__dirname, '../../../src', ...p);
+
+// GAS-style files (`var X = ...`, no imports). Load order matters: DATA_TYPES is read
+// at top level by ordersFields.js, and Source.js extends AbstractSource.
+loadGasClass(src('Constants/DataTypes.js'));
+loadGasClass(src('Sources/Shopify/ShopifyAPIReference/ordersFields.js'));
+loadGasClass(src('Core/AbstractSource.js'));
+loadGasClass(src('Sources/Shopify/Source.js'));
+
+const proto = globalThis.ShopifySource.prototype;
+const schema = { fields: globalThis.ordersFields };
+
+describe('orders checkoutToken', () => {
+  it('requests checkoutToken as a bare scalar', () => {
+    expect(proto._buildQueryFields.call(proto, schema, ['id', 'checkoutToken'])).toBe(
+      'id checkoutToken'
+    );
+  });
+
+  it('maps checkoutToken from the order node', () => {
+    const node = { id: 'gid://shopify/Order/1', checkoutToken: 'a1b2c3d4' };
+    expect(
+      proto._normalizeFromSchema.call(proto, { node, schema, fields: ['id', 'checkoutToken'] })
+    ).toEqual({ id: 'gid://shopify/Order/1', checkoutToken: 'a1b2c3d4' });
+  });
+
+  it('yields null when the order has no checkout token', () => {
+    const node = { id: 'gid://shopify/Order/2', checkoutToken: null };
+    expect(
+      proto._normalizeFromSchema.call(proto, { node, schema, fields: ['checkoutToken'] })
+    ).toEqual({ checkoutToken: null });
+  });
+});


### PR DESCRIPTION
# Problem

The Shopify connector had no way to import the checkout token of an order. Analysts who collect Shopify Web Pixel events (`checkout_completed`) could not join those events to imported orders, because the pixel identifies a purchase by `checkout.token` while the connector only exposed order IDs, names, and totals. The GraphQL Admin API `Order` object in the version the connector already pins (`2026-07`) provides this value as `checkoutToken`, but it was missing from the connector's `orders` field schema.

# Solution

Expose `checkoutToken` as an opt-in field on the `orders` node. The connector's query builder, value extractor, and storage schema are all driven by the per-node `*Fields.js` maps, so the change is a single schema entry with no logic changes in `Source.js` or `Connector.js`.

- Added the field to `ordersFields.js` with a plain `graphqlPath` of `checkoutToken`; the existing `_buildQueryFields` and `_normalizeFromSchema` handle it like any other scalar.
- Left `defaultFields` untouched so existing data marts keep the same query and table shape until a user selects the new field.
- Verified against the Shopify docs that `Order.checkoutToken` exists in `2026-07`, is not deprecated, and requires no additional scope, so no API version bump is needed. `AbandonedCheckout` has no token field, so that node is unchanged.
- Added the first unit test for the Shopify source, loading the real `DataTypes`, `ordersFields`, `AbstractSource`, and `ShopifySource` via the existing `loadGasClass` helper, covering query generation, value mapping, and the null case.

Historical orders will show `NULL` for this column until re-imported via a manual backfill, because incremental runs only revisit the reimport lookback window.

# Changes

- Added `checkoutToken` (STRING) to `packages/connectors/src/Sources/Shopify/ShopifyAPIReference/ordersFields.js`
- Added `packages/connectors/test/Sources/Shopify/Source.test.js` with three cases: query field emission, node-to-row mapping, and null handling
- Added changeset `.changeset/6883-shopify-order-checkout-token.md` (`owox: minor`)