### PR TITLE
docs(changeset): describe partition pruning in user terms

### DIFF
--- a/.changeset/6880-bq-merge-partition-pruning.md
+++ b/.changeset/6880-bq-merge-partition-pruning.md
@@ -2,6 +2,6 @@
 'owox': minor
 ---
 
-# Partition Pruning for BigQuery Connector Imports
+# Cheaper Incremental Imports into Google BigQuery
 
-Incremental connector runs into Google BigQuery now scan only the partitions they write, not the whole destination table. Before, every incremental MERGE scanned the full table history, so daily import cost grew with table age. A measured example: one two-day import dropped from 1.16 GB scanned to 3.89 MB. The saving applies to time-series tables partitioned by date, such as ad performance reports. Entity tables without a date column keep their current behavior. This lowers query costs and helps connectors stay within BigQuery daily quotas.
+Incremental connector runs into Google BigQuery now read only the days they update. Before, every incremental run scanned the whole destination table, including all of its history. As a table grew, each daily import cost more, even when it brought the same amount of new data. Now the import touches only the partitions for the imported dates, so the cost stays flat over time. This applies to time-series tables partitioned by date, such as ad performance reports. Entity tables without a date column, such as campaign lists, keep their current behavior. Users see lower BigQuery query costs and fewer daily quota errors.


### PR DESCRIPTION
# Problem

The changeset for #1579 (`6880-bq-merge-partition-pruning.md`) reads like an engineering note rather than a release note. It leads with "partition pruning" and "MERGE" — terms that mean nothing to the analysts and admins who read the changelog — and it cites a one-off benchmark ("1.16 GB scanned to 3.89 MB") measured on a synthetic test table. That number is not representative of any real destination and invites readers to expect a specific saving. The text also never states the outcome that actually matters to users: import cost no longer grows as a table ages.

# Solution

Rewrite the changeset body in plain language, keeping the same frontmatter (`'owox': minor`) and filename so the release tooling is unaffected. The new text describes the before/after from the user's point of view — imports used to re-read the whole table history every day, now they read only the days being updated, so cost stays flat over time. The synthetic benchmark is removed. Scope is stated concretely (date-partitioned time-series tables such as ad performance reports) with a named example of what is unchanged (entity tables such as campaign lists). Every sentence is under 20 words, active voice, per the docs style guide; markdownlint passes.

No code changes. The feature itself shipped in #1579; this only changes the release-notes text before the next release consumes the changeset.

# Changes

- Retitled the changeset from "Partition Pruning for BigQuery Connector Imports" to "Cheaper Incremental Imports into Google BigQuery"
- Removed the synthetic "1.16 GB → 3.89 MB" benchmark figure
- Rewrote the body to state that imports now read only the updated days and that cost no longer accumulates with table age
- Added a concrete example of unaffected tables (campaign lists) alongside the existing example of affected ones (ad performance reports)