### PR TITLE
chore(deps): bump qs to 6.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32699,9 +32699,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
## Why

The `Audit all` workflow started failing on every pull request after new advisories were published for `qs` (array-limit bypass via bracket-key comma parsing and a denial of service via attacker-controlled `isBuffer`). Nothing in the repository changed; the lockfile simply pins a version that is now flagged.

## What changes

`package-lock.json` only: `qs` 6.15.3 → 6.16.0 (a transitive dependency of `express` / `body-parser`). Its dependency ranges are unchanged, so the rest of the lockfile is untouched.

## Verification

- `npm audit --omit=dev` reports 0 vulnerabilities.
- `npm ls --package-lock-only` passes (lockfile consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
