### PR TITLE
feat(mcp): guide users whose project has no published data mart

### DIFF
--- a/.changeset/6808-mcp-empty-project-guidance.md
+++ b/.changeset/6808-mcp-empty-project-guidance.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# MCP: guidance for projects without Data Marts
+
+When a project has no published Data Mart visible to the connected user, the MCP discovery tools (`list_data_marts`, `get_relevant_data_marts_by_prompt`, and `summarize_data_catalog`) now return `getting_started` instead of a bare empty list: a link to create the first Data Mart in OWOX Data Marts, the setup guides, the user's draft Data Marts that still need publishing, and instructions the assistant relays to the user. The guidance depends on the user's role: Project Admins and Technical Users are walked through creating and publishing a Data Mart, while Business Users are advised to ask them for one.
+
+The MCP system instructions tell the assistant to stop rephrasing searches or querying data in that case and to explain what to do next in the web app instead, so a new user hears where to start rather than "no data found".

--- a/apps/backend/src/ee/mcp/instructions/mcp-instructions.service.spec.ts
+++ b/apps/backend/src/ee/mcp/instructions/mcp-instructions.service.spec.ts
@@ -47,6 +47,18 @@ describe('MCP instructions', () => {
     expect(MCP_SYSTEM_INSTRUCTIONS).toContain('Never call add_report again');
   });
 
+  // Without this rule the step-2 "rephrase and try again" advice sends a model into a loop of
+  // searches against a project that has nothing to find.
+  it('tells the assistant what to do when the project has no published data mart', () => {
+    expect(MCP_SYSTEM_INSTRUCTIONS).toContain('Empty project:');
+    expect(MCP_SYSTEM_INSTRUCTIONS).toContain('returns getting_started');
+    expect(MCP_SYSTEM_INSTRUCTIONS).toContain('Follow getting_started.instructions');
+    expect(MCP_SYSTEM_INSTRUCTIONS).toContain('do not rephrase and retry discovery tools');
+    expect(MCP_SYSTEM_INSTRUCTIONS).toContain(
+      'A Data Mart cannot be created or published through MCP'
+    );
+  });
+
   it('round-trips the complete system instructions through MCP initialization', async () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const server = new McpServer(

--- a/apps/backend/src/ee/mcp/instructions/mcp-system-instructions.ts
+++ b/apps/backend/src/ee/mcp/instructions/mcp-system-instructions.ts
@@ -2,7 +2,7 @@ export const MCP_SYSTEM_INSTRUCTIONS = `You have access to the current OWOX Data
 
 For a concrete analytical question:
 1. Call get_relevant_data_marts_by_prompt with the user's question unless the data mart has already been explicitly confirmed in the current conversation.
-2. If no useful result is returned, rephrase the search using different business terms and try again.
+2. If no useful result is returned, rephrase the search using different business terms and try again — unless the response contains getting_started (see "Empty project" below).
 3. If several data marts are plausible, ask the user which one to use.
 4. Call get_data_mart_details_by_id to obtain exact native field names unless that schema is already available in the conversation. It returns native fields by default. Before saying the selected Data Mart cannot answer the question, or after field_not_found, call it again with detail_level=with_joined_fields to inspect available joined fields. That response also includes "joins" — how each joined Data Mart relates to this one (join keys plus, when set, the analyst-written business meaning of the relationship); read it before interpreting joined fields or reasoning about cause and effect across them.
 5. Call query_data_mart with only the fields, filters, aggregations, date buckets, and sorting needed to answer the question.
@@ -11,6 +11,10 @@ Discovery:
 - Use list_data_marts only when the user explicitly asks to list or browse data marts.
 - Use summarize_data_catalog when the user asks what data is available, what can be analyzed, or does not know where to start.
 - Call get_project_context before the first project-specific operation in a conversation so you receive the current project metadata and its complete admin-maintained description. Reuse that context for subsequent requests unless the user asks you to refresh it.
+
+Empty project:
+- When list_data_marts, get_relevant_data_marts_by_prompt, or summarize_data_catalog returns getting_started, the user has no published Data Mart to work with yet. Follow getting_started.instructions: explain what a Data Mart is, relay the links (create_data_mart_url or data_marts_url, and guides) and any draft_data_marts, and say what to do next in the OWOX Data Marts web app. A Data Mart cannot be created or published through MCP.
+- In that case do not rephrase and retry discovery tools, and do not call get_data_mart_details_by_id, query_data_mart, or any report or schedule tool until a published Data Mart exists.
 
 Rules:
 - Never ask the user to provide SQL and never generate SQL yourself. query_data_mart builds and executes the query internally.

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -156,7 +156,77 @@ describe('ListDataMartsTool', () => {
 
     const result = await tool.handler({}, context);
 
-    expect(result.structuredContent).toEqual({ data_marts: [] });
+    expect(result.structuredContent).toEqual({
+      data_marts: [],
+      getting_started: expect.objectContaining({ reason: 'no_published_data_marts' }),
+    });
+  });
+
+  it('guides the user when the published catalog is empty, naming visible drafts', async () => {
+    const facade = {
+      listDataMarts: jest.fn(async ({ status }: { status: string }) => ({
+        dataMarts:
+          status === 'draft'
+            ? [
+                {
+                  id: 'dm_draft',
+                  title: 'Draft Orders',
+                  description: null,
+                  status: DataMartStatus.DRAFT,
+                  updatedAt: '2026-06-11T10:00:00.000Z',
+                },
+              ]
+            : [],
+      })),
+    } as unknown as jest.Mocked<McpDataMartsFacade>;
+    const tool = new ListDataMartsTool(facade, publicOrigin, projectContext as never);
+
+    const result = await tool.handler({}, context);
+
+    expect(result.structuredContent).toEqual({
+      project: { id: 'project-1', title: 'Analytics' },
+      data_marts: [],
+      getting_started: expect.objectContaining({
+        reason: 'no_published_data_marts',
+        can_create_data_marts: false,
+        create_data_mart_url: 'https://app.owox.com/ui/project-1/data-marts/create',
+        draft_data_marts: [
+          {
+            id: 'dm_draft',
+            title: 'Draft Orders',
+            url: 'https://app.owox.com/ui/project-1/data-marts/dm_draft/data-setup',
+          },
+        ],
+      }),
+    });
+    expect(facade.listDataMarts).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not guide on an empty draft list while a published data mart exists', async () => {
+    const facade = {
+      listDataMarts: jest.fn(async ({ status }: { status: string }) => ({
+        dataMarts:
+          status === 'published'
+            ? [
+                {
+                  id: 'dm_1',
+                  title: 'Orders',
+                  description: null,
+                  status: DataMartStatus.PUBLISHED,
+                  updatedAt: '2026-06-10T10:00:00.000Z',
+                },
+              ]
+            : [],
+      })),
+    } as unknown as jest.Mocked<McpDataMartsFacade>;
+    const tool = new ListDataMartsTool(facade, publicOrigin, projectContext as never);
+
+    const result = await tool.handler({ status: 'draft' }, context);
+
+    expect(result.structuredContent).toEqual({
+      project: { id: 'project-1', title: 'Analytics' },
+      data_marts: [],
+    });
   });
 
   // Note: MCP_TOOL_PROVIDER_CLASSES assertion checks the LOCAL test registry snapshot, not
@@ -175,6 +245,7 @@ describe('ListDataMartsTool', () => {
       outputSchema: expect.objectContaining({
         project: expect.any(Object),
         data_marts: expect.any(Object),
+        getting_started: expect.any(Object),
       }),
       annotations: {
         title: 'List Data Marts',

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { PublicOriginService } from '../../../common/config/public-origin.service';
 import { DataMartStatus } from '../../../data-marts/enums/data-mart-status.enum';
 import type { McpDataMartsFacade } from '../../../data-marts/facades/mcp-data-marts.facade';
@@ -200,6 +201,29 @@ describe('ListDataMartsTool', () => {
       }),
     });
     expect(facade.listDataMarts).toHaveBeenCalledTimes(2);
+    // The SDK validates structuredContent against outputSchema at call time, so a key required by
+    // gettingStartedSchema but missing from buildGettingStarted would fail every empty project.
+    expect(() => z.object(tool.outputSchema).parse(result.structuredContent)).not.toThrow();
+  });
+
+  it('guides on an empty draft list when no published data mart exists either', async () => {
+    const facade = {
+      listDataMarts: jest.fn().mockResolvedValue({ dataMarts: [] }),
+    } as unknown as jest.Mocked<McpDataMartsFacade>;
+    const tool = new ListDataMartsTool(facade, publicOrigin, projectContext as never);
+
+    const result = await tool.handler({ status: 'draft' }, context);
+
+    expect(result.structuredContent).toEqual({
+      project: { id: 'project-1', title: 'Analytics' },
+      data_marts: [],
+      getting_started: expect.objectContaining({
+        reason: 'no_published_data_marts',
+        draft_data_marts: [],
+      }),
+    });
+    const statuses = facade.listDataMarts.mock.calls.map(([request]) => request.status);
+    expect(statuses).toEqual(['draft', 'published', 'draft']);
   });
 
   it('does not guide on an empty draft list while a published data mart exists', async () => {

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.ts
@@ -13,6 +13,11 @@ import {
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
 import { buildDataMartUiPath } from './data-mart-ui-path';
+import {
+  buildGettingStarted,
+  gettingStartedSchema,
+  resolveGettingStarted,
+} from './mcp-getting-started.util';
 import { tryGetMcpProjectSummary } from './mcp-project-summary.util';
 import { joinPublicOrigin } from './mcp-public-url.util';
 
@@ -47,6 +52,11 @@ export class ListDataMartsTool implements McpToolDefinition<ListDataMartsInput> 
         updated_at: z.string(),
       })
     ),
+    getting_started: gettingStartedSchema
+      .optional()
+      .describe(
+        'Present only when the user sees no published data mart: links and next steps for creating the first one. Relay its instructions instead of retrying discovery.'
+      ),
   };
   readonly annotations = {
     title: 'List Data Marts',
@@ -70,18 +80,23 @@ export class ListDataMartsTool implements McpToolDefinition<ListDataMartsInput> 
 
   async handler(input: ListDataMartsInput, context: McpAuthContext): Promise<McpToolResult> {
     const parsed = this.parseInput(input);
+    const status = parsed.status ?? 'published';
 
     const [result, projectContext] = await Promise.all([
       this.dataMarts.listDataMarts({
         projectId: context.projectId,
         userId: context.userId,
         roles: context.roles,
-        status: parsed.status ?? 'published',
+        status,
       }),
       tryGetMcpProjectSummary(this.projectContext, context),
     ]);
 
     const publicOrigin = this.publicOriginService.getPublicOrigin();
+    const gettingStarted = await this.gettingStartedFor(result.dataMarts.length, status, {
+      publicOrigin,
+      context,
+    });
     const structuredContent = {
       ...(projectContext ? { project: projectContext } : {}),
       data_marts: result.dataMarts.map(dataMart => ({
@@ -92,8 +107,25 @@ export class ListDataMartsTool implements McpToolDefinition<ListDataMartsInput> 
         status: dataMart.status,
         updated_at: dataMart.updatedAt,
       })),
+      ...(gettingStarted ? { getting_started: gettingStarted } : {}),
     };
 
     return jsonToolResult(structuredContent);
+  }
+
+  /**
+   * An empty published list is the empty-project case by itself. An empty draft list says
+   * nothing about published data marts, so that case checks the published catalog first.
+   */
+  private async gettingStartedFor(
+    listedCount: number,
+    status: 'published' | 'draft',
+    { publicOrigin, context }: { publicOrigin: string; context: McpAuthContext }
+  ) {
+    if (listedCount > 0) return undefined;
+    const deps = { dataMarts: this.dataMarts, publicOrigin };
+    return status === 'published'
+      ? buildGettingStarted(deps, context)
+      : resolveGettingStarted(deps, context);
   }
 }

--- a/apps/backend/src/ee/mcp/tools/data-mart-ui-path.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-ui-path.ts
@@ -14,3 +14,11 @@ export function buildDataDestinationsUiPath(projectId: string, destinationId?: s
 export function buildReportSchedulesUiPath(projectId: string): string {
   return `/ui/${encodeURIComponent(projectId)}/data-marts/schedules`;
 }
+
+export function buildDataMartsUiPath(projectId: string): string {
+  return `/ui/${encodeURIComponent(projectId)}/data-marts`;
+}
+
+export function buildCreateDataMartUiPath(projectId: string): string {
+  return `/ui/${encodeURIComponent(projectId)}/data-marts/create`;
+}

--- a/apps/backend/src/ee/mcp/tools/mcp-docs-urls.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-docs-urls.ts
@@ -11,3 +11,24 @@
  */
 export const LOOKER_STUDIO_DESTINATION_GUIDE_URL =
   'https://docs.owox.com/docs/destinations/supported-destinations/data-studio/';
+
+/**
+ * What a Data Mart is and how the OWOX Data Marts entities fit together — the first
+ * page for a user whose project has no Data Mart yet. Source: docs/getting-started/core-concepts.md.
+ */
+export const DATA_MARTS_CORE_CONCEPTS_URL =
+  'https://docs.owox.com/docs/getting-started/core-concepts/';
+
+/**
+ * Creating a connector-based Data Mart (Facebook Ads, Google Ads, TikTok Ads, ...).
+ * Source: docs/getting-started/setup-guide/connector-data-mart.md.
+ */
+export const CONNECTOR_DATA_MART_GUIDE_URL =
+  'https://docs.owox.com/docs/getting-started/setup-guide/connector-data-mart/';
+
+/**
+ * Creating an SQL-based Data Mart on a connected storage.
+ * Source: docs/getting-started/setup-guide/sql-data-mart.md.
+ */
+export const SQL_DATA_MART_GUIDE_URL =
+  'https://docs.owox.com/docs/getting-started/setup-guide/sql-data-mart/';

--- a/apps/backend/src/ee/mcp/tools/mcp-getting-started.util.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-getting-started.util.spec.ts
@@ -1,0 +1,158 @@
+import type { McpDataMartsFacade } from '../../../data-marts/facades/mcp-data-marts.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import {
+  buildGettingStarted,
+  gettingStartedSchema,
+  hasPublishedDataMarts,
+  resolveGettingStarted,
+} from './mcp-getting-started.util';
+
+describe('MCP getting-started guidance', () => {
+  const baseContext: McpAuthContext = {
+    clientId: 'mcp-client-1',
+    userId: 'user-1',
+    projectId: 'project 1',
+    roles: ['editor'],
+    resource: 'https://mcp.owox.com/mcp',
+    scopes: ['mcp:read'],
+    authFlow: 'mcp',
+  };
+  const publicOrigin = 'https://app.owox.com/';
+
+  function facadeWith(byStatus: Partial<Record<'published' | 'draft', unknown[]>>) {
+    return {
+      listDataMarts: jest.fn(async ({ status }: { status: 'published' | 'draft' }) => ({
+        dataMarts: byStatus[status] ?? [],
+      })),
+    } as unknown as jest.Mocked<McpDataMartsFacade>;
+  }
+
+  it('links a creator role to the create page, the guides, and the creation steps', async () => {
+    const dataMarts = facadeWith({});
+
+    const guidance = await buildGettingStarted({ dataMarts, publicOrigin }, baseContext);
+
+    expect(guidance).toEqual({
+      reason: 'no_published_data_marts',
+      can_create_data_marts: true,
+      create_data_mart_url: 'https://app.owox.com/ui/project%201/data-marts/create',
+      data_marts_url: 'https://app.owox.com/ui/project%201/data-marts',
+      guides: {
+        core_concepts: 'https://docs.owox.com/docs/getting-started/core-concepts/',
+        connector_data_mart:
+          'https://docs.owox.com/docs/getting-started/setup-guide/connector-data-mart/',
+        sql_data_mart: 'https://docs.owox.com/docs/getting-started/setup-guide/sql-data-mart/',
+      },
+      draft_data_marts: [],
+      instructions: expect.stringContaining('open create_data_mart_url'),
+    });
+    expect(guidance.instructions).toContain('publish');
+    expect(guidance.instructions).toContain('Do not retry discovery tools');
+    expect(guidance.instructions).not.toContain('draft_data_marts');
+    expect(() => gettingStartedSchema.parse(guidance)).not.toThrow();
+    expect(dataMarts.listDataMarts).toHaveBeenCalledWith({
+      projectId: 'project 1',
+      userId: 'user-1',
+      roles: ['editor'],
+      status: 'draft',
+    });
+  });
+
+  it('tells a business user to ask a creator role instead of sending them to the create page', async () => {
+    const guidance = await buildGettingStarted(
+      { dataMarts: facadeWith({}), publicOrigin },
+      { ...baseContext, roles: ['viewer'] }
+    );
+
+    expect(guidance.can_create_data_marts).toBe(false);
+    expect(guidance.instructions).toContain('cannot create Data Marts');
+    expect(guidance.instructions).toContain('Project Admin or a Technical User');
+    expect(guidance.instructions).not.toContain('open create_data_mart_url');
+  });
+
+  it('treats an admin as a creator', async () => {
+    const guidance = await buildGettingStarted(
+      { dataMarts: facadeWith({}), publicOrigin },
+      { ...baseContext, roles: ['admin'] }
+    );
+
+    expect(guidance.can_create_data_marts).toBe(true);
+  });
+
+  it('lists visible drafts with their pages and asks to publish them', async () => {
+    const dataMarts = facadeWith({
+      draft: [
+        {
+          id: 'dm_draft',
+          title: 'Draft Orders',
+          description: null,
+          status: 'DRAFT',
+          updatedAt: '',
+        },
+      ],
+    });
+
+    const guidance = await buildGettingStarted({ dataMarts, publicOrigin }, baseContext);
+
+    expect(guidance.draft_data_marts).toEqual([
+      {
+        id: 'dm_draft',
+        title: 'Draft Orders',
+        url: 'https://app.owox.com/ui/project%201/data-marts/dm_draft/data-setup',
+      },
+    ]);
+    expect(guidance.instructions).toContain('1 draft Data Mart(s) listed in draft_data_marts');
+    expect(guidance.instructions).toContain('finished, and published');
+  });
+
+  it('asks a business user to have drafts published by someone else', async () => {
+    const dataMarts = facadeWith({
+      draft: [
+        { id: 'dm_draft', title: 'Draft', description: null, status: 'DRAFT', updatedAt: '' },
+      ],
+    });
+
+    const guidance = await buildGettingStarted(
+      { dataMarts, publicOrigin },
+      { ...baseContext, roles: ['viewer'] }
+    );
+
+    expect(guidance.instructions).toContain('published by a Project Admin or a Technical User');
+  });
+
+  it('keeps the links and steps when the draft lookup fails', async () => {
+    const dataMarts = {
+      listDataMarts: jest.fn().mockRejectedValue(new Error('db down')),
+    } as unknown as jest.Mocked<McpDataMartsFacade>;
+
+    const guidance = await buildGettingStarted({ dataMarts, publicOrigin }, baseContext);
+
+    expect(guidance.draft_data_marts).toEqual([]);
+    expect(guidance.create_data_mart_url).toBe(
+      'https://app.owox.com/ui/project%201/data-marts/create'
+    );
+  });
+
+  it('resolves to nothing when the user sees a published data mart', async () => {
+    const dataMarts = facadeWith({
+      published: [
+        { id: 'dm_1', title: 'Orders', description: null, status: 'PUBLISHED', updatedAt: '' },
+      ],
+    });
+
+    await expect(hasPublishedDataMarts(dataMarts, baseContext)).resolves.toBe(true);
+    await expect(
+      resolveGettingStarted({ dataMarts, publicOrigin }, baseContext)
+    ).resolves.toBeUndefined();
+    expect(dataMarts.listDataMarts).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves to guidance when the user sees no published data mart', async () => {
+    const dataMarts = facadeWith({});
+
+    await expect(hasPublishedDataMarts(dataMarts, baseContext)).resolves.toBe(false);
+    await expect(
+      resolveGettingStarted({ dataMarts, publicOrigin }, baseContext)
+    ).resolves.toMatchObject({ reason: 'no_published_data_marts' });
+  });
+});

--- a/apps/backend/src/ee/mcp/tools/mcp-getting-started.util.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-getting-started.util.spec.ts
@@ -70,6 +70,21 @@ describe('MCP getting-started guidance', () => {
     expect(guidance.instructions).not.toContain('open create_data_mart_url');
   });
 
+  // The flag mirrors the STORAGE/USE gate of CreateDataMartService; these are the outcomes the
+  // access matrix yields today, so a matrix change that alters them shows up here.
+  it('derives creator roles from the access matrix', async () => {
+    const dataMarts = facadeWith({});
+    const canCreate = async (roles: string[]) =>
+      (await buildGettingStarted({ dataMarts, publicOrigin }, { ...baseContext, roles }))
+        .can_create_data_marts;
+
+    await expect(canCreate(['admin'])).resolves.toBe(true);
+    await expect(canCreate(['editor'])).resolves.toBe(true);
+    await expect(canCreate(['viewer'])).resolves.toBe(false);
+    await expect(canCreate(['viewer', 'editor'])).resolves.toBe(true);
+    await expect(canCreate([])).resolves.toBe(false);
+  });
+
   it('treats an admin as a creator', async () => {
     const guidance = await buildGettingStarted(
       { dataMarts: facadeWith({}), publicOrigin },

--- a/apps/backend/src/ee/mcp/tools/mcp-getting-started.util.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-getting-started.util.ts
@@ -2,6 +2,11 @@ import { castError } from '@owox/internal-helpers';
 import { Logger } from '@nestjs/common';
 import { z } from 'zod';
 import type { McpDataMartsFacade } from '../../../data-marts/facades/mcp-data-marts.facade';
+import { ACCESS_MATRIX } from '../../../data-marts/services/access-decision/access-matrix.config';
+import {
+  Action,
+  EntityType,
+} from '../../../data-marts/services/access-decision/access-decision.types';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import {
   buildCreateDataMartUiPath,
@@ -18,10 +23,17 @@ import { joinPublicOrigin } from './mcp-public-url.util';
 const logger = new Logger('McpGettingStarted');
 
 /**
- * Project roles allowed to create and publish Data Marts in the web app (Project Admin and
- * Technical User). A Business User (`viewer`) can only work with Data Marts shared with them.
+ * Roles that can create a Data Mart. The backend gates creation on STORAGE/USE
+ * (CreateDataMartService), so a role the access matrix lets use a storage in at least one
+ * ownership/sharing state qualifies. Derived from the matrix instead of listed by hand so the
+ * assistant's role advice cannot drift from what the backend enforces — today Project Admin
+ * and Technical User; a Business User (`viewer`) is denied on every state.
  */
-const DATA_MART_CREATOR_ROLES: ReadonlySet<string> = new Set(['admin', 'editor']);
+const DATA_MART_CREATOR_ROLES: ReadonlySet<string> = new Set(
+  ACCESS_MATRIX.filter(
+    rule => rule.entityType === EntityType.STORAGE && rule.action === Action.USE && rule.result
+  ).map(rule => rule.role)
+);
 
 /**
  * Attached to a discovery tool result when the user sees no published Data Mart, so the

--- a/apps/backend/src/ee/mcp/tools/mcp-getting-started.util.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-getting-started.util.ts
@@ -1,0 +1,167 @@
+import { castError } from '@owox/internal-helpers';
+import { Logger } from '@nestjs/common';
+import { z } from 'zod';
+import type { McpDataMartsFacade } from '../../../data-marts/facades/mcp-data-marts.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import {
+  buildCreateDataMartUiPath,
+  buildDataMartsUiPath,
+  buildDataMartUiPath,
+} from './data-mart-ui-path';
+import {
+  CONNECTOR_DATA_MART_GUIDE_URL,
+  DATA_MARTS_CORE_CONCEPTS_URL,
+  SQL_DATA_MART_GUIDE_URL,
+} from './mcp-docs-urls';
+import { joinPublicOrigin } from './mcp-public-url.util';
+
+const logger = new Logger('McpGettingStarted');
+
+/**
+ * Project roles allowed to create and publish Data Marts in the web app (Project Admin and
+ * Technical User). A Business User (`viewer`) can only work with Data Marts shared with them.
+ */
+const DATA_MART_CREATOR_ROLES: ReadonlySet<string> = new Set(['admin', 'editor']);
+
+/**
+ * Attached to a discovery tool result when the user sees no published Data Mart, so the
+ * assistant can explain what to do next instead of reporting an empty catalog. Every MCP
+ * data-mart tool works with published Data Marts only, and a Data Mart can be created and
+ * published only in the web app — hence the deep links and guides rather than a tool call.
+ */
+export const gettingStartedSchema = z.object({
+  reason: z.literal('no_published_data_marts'),
+  can_create_data_marts: z
+    .boolean()
+    .describe('Whether the current user role may create and publish Data Marts.'),
+  create_data_mart_url: z
+    .string()
+    .describe('Page in OWOX Data Marts where the user creates a new Data Mart.'),
+  data_marts_url: z.string().describe('Data Marts list page of the current project.'),
+  guides: z.object({
+    core_concepts: z.string(),
+    connector_data_mart: z.string(),
+    sql_data_mart: z.string(),
+  }),
+  draft_data_marts: z
+    .array(z.object({ id: z.string(), title: z.string(), url: z.string() }))
+    .describe('Draft Data Marts visible to the user; unavailable through MCP until published.'),
+  instructions: z.string().describe('What to tell the user; relay it in their language.'),
+});
+
+export type McpGettingStarted = z.infer<typeof gettingStartedSchema>;
+
+export interface McpGettingStartedDeps {
+  dataMarts: McpDataMartsFacade;
+  publicOrigin: string;
+}
+
+/** Whether the user sees at least one published Data Mart in the current project. */
+export async function hasPublishedDataMarts(
+  dataMarts: McpDataMartsFacade,
+  context: McpAuthContext
+): Promise<boolean> {
+  const result = await dataMarts.listDataMarts({
+    projectId: context.projectId,
+    userId: context.userId,
+    roles: context.roles,
+    status: 'published',
+  });
+  return result.dataMarts.length > 0;
+}
+
+/**
+ * Guidance for a user who sees no published Data Mart, or `undefined` when they do see one
+ * (an empty search result then just means nothing matched). Use when the published catalog
+ * has not been fetched yet; call `buildGettingStarted` directly when it is known to be empty.
+ */
+export async function resolveGettingStarted(
+  deps: McpGettingStartedDeps,
+  context: McpAuthContext
+): Promise<McpGettingStarted | undefined> {
+  if (await hasPublishedDataMarts(deps.dataMarts, context)) return undefined;
+  return buildGettingStarted(deps, context);
+}
+
+/**
+ * Builds the guidance once the published catalog visible to the user is known to be empty.
+ * The draft lookup is best-effort: the links and role-specific steps are still useful when
+ * that enrichment fails, so a failure only drops the draft list.
+ */
+export async function buildGettingStarted(
+  deps: McpGettingStartedDeps,
+  context: McpAuthContext
+): Promise<McpGettingStarted> {
+  const canCreate = context.roles.some(role => DATA_MART_CREATOR_ROLES.has(role));
+  const drafts = await listVisibleDrafts(deps, context);
+
+  return {
+    reason: 'no_published_data_marts',
+    can_create_data_marts: canCreate,
+    create_data_mart_url: joinPublicOrigin(
+      deps.publicOrigin,
+      buildCreateDataMartUiPath(context.projectId)
+    ),
+    data_marts_url: joinPublicOrigin(deps.publicOrigin, buildDataMartsUiPath(context.projectId)),
+    guides: {
+      core_concepts: DATA_MARTS_CORE_CONCEPTS_URL,
+      connector_data_mart: CONNECTOR_DATA_MART_GUIDE_URL,
+      sql_data_mart: SQL_DATA_MART_GUIDE_URL,
+    },
+    draft_data_marts: drafts,
+    instructions: buildInstructions(canCreate, drafts.length),
+  };
+}
+
+async function listVisibleDrafts(
+  deps: McpGettingStartedDeps,
+  context: McpAuthContext
+): Promise<McpGettingStarted['draft_data_marts']> {
+  try {
+    const result = await deps.dataMarts.listDataMarts({
+      projectId: context.projectId,
+      userId: context.userId,
+      roles: context.roles,
+      status: 'draft',
+    });
+    return result.dataMarts.map(dataMart => ({
+      id: dataMart.id,
+      title: dataMart.title,
+      url: joinPublicOrigin(deps.publicOrigin, buildDataMartUiPath(context.projectId, dataMart.id)),
+    }));
+  } catch (error: unknown) {
+    logger.warn('Failed to list draft data marts for MCP getting-started guidance', {
+      projectId: context.projectId,
+      error: castError(error).message,
+    });
+    return [];
+  }
+}
+
+function buildInstructions(canCreate: boolean, draftCount: number): string {
+  const parts: string[] = [
+    canCreate
+      ? 'This project has no published Data Mart visible to the user, so there is nothing to explore or query through MCP yet.'
+      : 'No published Data Mart is shared with the user in this project, so there is nothing to explore or query through MCP yet.',
+    'Explain in one or two sentences that a Data Mart is a reusable dataset defined in OWOX Data Marts — data collected from a connector (for example Facebook Ads, Google Ads, or TikTok Ads) or defined as SQL, a table, or a view on a connected storage — and that MCP works only with published Data Marts.',
+  ];
+
+  if (draftCount > 0) {
+    parts.push(
+      `The user can see ${draftCount} draft Data Mart(s) listed in draft_data_marts; name them with their url. Drafts are not available through MCP until they are ${
+        canCreate
+          ? 'opened in the OWOX Data Marts web app, finished, and published.'
+          : 'published by a Project Admin or a Technical User.'
+      }`
+    );
+  }
+
+  parts.push(
+    canCreate
+      ? 'The user can create Data Marts. Walk them through the steps: 1) open create_data_mart_url in the OWOX Data Marts web app; 2) connect a data source or define the Data Mart from SQL, a table, or a view on a connected storage; 3) save and publish it. Share create_data_mart_url and the matching guide from guides.'
+      : 'The user role (Business User) cannot create Data Marts. Advise them to ask a Project Admin or a Technical User of this project to create and publish a Data Mart and share it with them for reporting. Share data_marts_url and guides.core_concepts so they can pass them on.',
+    'Once a published Data Mart is available, the user can simply ask again. Do not retry discovery tools with different wording, and do not call query_data_mart or any report or schedule tool until then.'
+  );
+
+  return parts.join(' ');
+}

--- a/apps/backend/src/ee/mcp/tools/search-data-marts.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/search-data-marts.tool.spec.ts
@@ -1,6 +1,7 @@
 import type { PublicOriginService } from '../../../common/config/public-origin.service';
 import type { SearchFacade } from '../../../common/search/search.facade';
 import { SearchableEntityType } from '../../../common/search/search.facade';
+import type { McpDataMartsFacade } from '../../../data-marts/facades/mcp-data-marts.facade';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import { SearchDataMartsTool } from './search-data-marts.tool';
 
@@ -22,6 +23,21 @@ describe('SearchDataMartsTool', () => {
       project: { id: 'project-1', title: 'Analytics' },
     }),
   };
+  const publishedDataMart = {
+    id: 'dm_1',
+    title: 'Orders',
+    description: null,
+    status: 'PUBLISHED',
+    updatedAt: '2026-06-10T10:00:00.000Z',
+  };
+  function catalogWith(published: unknown[]) {
+    return {
+      listDataMarts: jest.fn(async ({ status }: { status: string }) => ({
+        dataMarts: status === 'published' ? published : [],
+      })),
+    } as unknown as jest.Mocked<McpDataMartsFacade>;
+  }
+  const catalog = catalogWith([publishedDataMart]);
 
   it('searches only non-draft data marts visible to the MCP project member', async () => {
     const facade = {
@@ -37,7 +53,7 @@ describe('SearchDataMartsTool', () => {
         },
       ]),
     } as unknown as jest.Mocked<SearchFacade>;
-    const tool = new SearchDataMartsTool(facade, publicOrigin, projectContext as never);
+    const tool = new SearchDataMartsTool(facade, publicOrigin, projectContext as never, catalog);
 
     await expect(tool.handler({ prompt: 'orders revenue', limit: 5 }, context)).resolves.toEqual({
       structuredContent: {
@@ -89,7 +105,7 @@ describe('SearchDataMartsTool', () => {
     const facade = {
       search: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<SearchFacade>;
-    const tool = new SearchDataMartsTool(facade, publicOrigin, projectContext as never);
+    const tool = new SearchDataMartsTool(facade, publicOrigin, projectContext as never, catalog);
 
     await tool.handler({ prompt: 'orders' }, context);
 
@@ -107,15 +123,83 @@ describe('SearchDataMartsTool', () => {
     const unavailableProjectContext = {
       getProjectContext: jest.fn().mockRejectedValue(new Error('Project context unavailable')),
     };
-    const tool = new SearchDataMartsTool(facade, publicOrigin, unavailableProjectContext as never);
+    const tool = new SearchDataMartsTool(
+      facade,
+      publicOrigin,
+      unavailableProjectContext as never,
+      catalog
+    );
 
     const result = await tool.handler({ prompt: 'orders' }, context);
 
     expect(result.structuredContent).toEqual({ data_marts: [] });
   });
 
+  it('does not guide when nothing matched but a published data mart exists', async () => {
+    const facade = {
+      search: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<SearchFacade>;
+    const tool = new SearchDataMartsTool(facade, publicOrigin, projectContext as never, catalog);
+
+    const result = await tool.handler({ prompt: 'orders' }, context);
+
+    expect(result.structuredContent).toEqual({
+      project: { id: 'project-1', title: 'Analytics' },
+      data_marts: [],
+    });
+  });
+
+  it('does not touch the catalog when the search found something', async () => {
+    const facade = {
+      search: jest.fn().mockResolvedValue([
+        {
+          entityType: SearchableEntityType.DATA_MART,
+          entityId: 'dm_1',
+          title: 'Orders',
+          description: null,
+          finalScore: 91,
+          kwScore: 74,
+          vecScore: 83,
+        },
+      ]),
+    } as unknown as jest.Mocked<SearchFacade>;
+    const untouched = catalogWith([]);
+    const tool = new SearchDataMartsTool(facade, publicOrigin, projectContext as never, untouched);
+
+    await tool.handler({ prompt: 'orders' }, context);
+
+    expect(untouched.listDataMarts).not.toHaveBeenCalled();
+  });
+
+  it('guides the user when the project has no published data mart', async () => {
+    const facade = {
+      search: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<SearchFacade>;
+    const empty = catalogWith([]);
+    const tool = new SearchDataMartsTool(facade, publicOrigin, projectContext as never, empty);
+
+    const result = await tool.handler({ prompt: 'orders' }, context);
+
+    expect(result.structuredContent).toEqual({
+      project: { id: 'project-1', title: 'Analytics' },
+      data_marts: [],
+      getting_started: expect.objectContaining({
+        reason: 'no_published_data_marts',
+        can_create_data_marts: false,
+        create_data_mart_url: 'https://app.owox.com/ui/project-1/data-marts/create',
+        data_marts_url: 'https://app.owox.com/ui/project-1/data-marts',
+        draft_data_marts: [],
+      }),
+    });
+  });
+
   it('rejects explicit project_id, legacy query, and too-wide limits', () => {
-    const tool = new SearchDataMartsTool({} as SearchFacade, publicOrigin, projectContext as never);
+    const tool = new SearchDataMartsTool(
+      {} as SearchFacade,
+      publicOrigin,
+      projectContext as never,
+      catalog
+    );
 
     expect(() => tool.parseInput({ prompt: 'orders', project_id: 'another-project' })).toThrow();
     expect(() => tool.parseInput({ query: 'orders' })).toThrow();
@@ -123,7 +207,12 @@ describe('SearchDataMartsTool', () => {
   });
 
   it('describes that it only searches non-draft data marts', () => {
-    const tool = new SearchDataMartsTool({} as SearchFacade, publicOrigin, projectContext as never);
+    const tool = new SearchDataMartsTool(
+      {} as SearchFacade,
+      publicOrigin,
+      projectContext as never,
+      catalog
+    );
 
     expect(tool).toMatchObject({
       name: 'get_relevant_data_marts_by_prompt',
@@ -131,6 +220,7 @@ describe('SearchDataMartsTool', () => {
       outputSchema: expect.objectContaining({
         project: expect.any(Object),
         data_marts: expect.any(Object),
+        getting_started: expect.any(Object),
       }),
       annotations: {
         title: 'Find Relevant Data Marts by Prompt',

--- a/apps/backend/src/ee/mcp/tools/search-data-marts.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/search-data-marts.tool.ts
@@ -8,12 +8,17 @@ import {
 } from '../../../common/search/search.facade';
 import { PublicOriginService } from '../../../common/config/public-origin.service';
 import {
+  MCP_DATA_MARTS_FACADE,
+  type McpDataMartsFacade,
+} from '../../../data-marts/facades/mcp-data-marts.facade';
+import {
   MCP_PROJECT_CONTEXT_FACADE,
   type McpProjectContextFacade,
 } from '../../../idp/facades/mcp-project-context.facade';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
 import { buildDataMartUiPath } from './data-mart-ui-path';
+import { gettingStartedSchema, resolveGettingStarted } from './mcp-getting-started.util';
 import { tryGetMcpProjectSummary } from './mcp-project-summary.util';
 import { joinPublicOrigin } from './mcp-public-url.util';
 
@@ -46,6 +51,11 @@ export class SearchDataMartsTool implements McpToolDefinition<SearchDataMartsInp
         relevance_score: z.number(),
       })
     ),
+    getting_started: gettingStartedSchema
+      .optional()
+      .describe(
+        'Present only when the user sees no published data mart at all (not when the search simply found nothing): links and next steps for creating the first one. Relay its instructions instead of rephrasing the search.'
+      ),
   };
   readonly annotations = {
     title: 'Find Relevant Data Marts by Prompt',
@@ -60,7 +70,9 @@ export class SearchDataMartsTool implements McpToolDefinition<SearchDataMartsInp
     private readonly searchFacade: SearchFacade,
     private readonly publicOriginService: PublicOriginService,
     @Inject(MCP_PROJECT_CONTEXT_FACADE)
-    private readonly projectContext: McpProjectContextFacade
+    private readonly projectContext: McpProjectContextFacade,
+    @Inject(MCP_DATA_MARTS_FACADE)
+    private readonly dataMarts: McpDataMartsFacade
   ) {}
 
   parseInput(input: unknown): SearchDataMartsInput {
@@ -83,20 +95,28 @@ export class SearchDataMartsTool implements McpToolDefinition<SearchDataMartsInp
     ]);
 
     const publicOrigin = this.publicOriginService.getPublicOrigin();
+    const dataMarts = results
+      .filter(result => result.entityType === SearchableEntityType.DATA_MART)
+      .map(result => ({
+        id: result.entityId,
+        title: result.title,
+        description: result.description ?? '',
+        url: joinPublicOrigin(
+          publicOrigin,
+          buildDataMartUiPath(context.projectId, result.entityId)
+        ),
+        relevance_score: result.finalScore,
+      }));
+    // An empty search result is ambiguous: nothing matched, or there is nothing to match. Only
+    // the latter deserves onboarding guidance, so the catalog itself is checked before guiding.
+    const gettingStarted =
+      dataMarts.length === 0
+        ? await resolveGettingStarted({ dataMarts: this.dataMarts, publicOrigin }, context)
+        : undefined;
     const structuredContent = {
       ...(projectContext ? { project: projectContext } : {}),
-      data_marts: results
-        .filter(result => result.entityType === SearchableEntityType.DATA_MART)
-        .map(result => ({
-          id: result.entityId,
-          title: result.title,
-          description: result.description ?? '',
-          url: joinPublicOrigin(
-            publicOrigin,
-            buildDataMartUiPath(context.projectId, result.entityId)
-          ),
-          relevance_score: result.finalScore,
-        })),
+      data_marts: dataMarts,
+      ...(gettingStarted ? { getting_started: gettingStarted } : {}),
     };
 
     return jsonToolResult(structuredContent);

--- a/apps/backend/src/ee/mcp/tools/summarize-data-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/summarize-data-catalog.tool.spec.ts
@@ -112,7 +112,7 @@ describe('SummarizeDataCatalogTool', () => {
     const facade = {
       summarizeDataCatalog: jest.fn().mockResolvedValue({
         projectId: 'project-1',
-        dataMartCount: 0,
+        dataMartCount: 1,
         topDataMartsByConnectivity: [],
       }),
     } as unknown as jest.Mocked<McpDataMartsFacade>;
@@ -129,10 +129,43 @@ describe('SummarizeDataCatalogTool', () => {
 
     expect(result.structuredContent).toMatchObject({
       project_id: 'project-1',
-      data_mart_count: 0,
+      data_mart_count: 1,
       top_data_marts_by_connectivity: [],
     });
     expect(result.structuredContent).not.toHaveProperty('project');
+    expect(result.structuredContent).not.toHaveProperty('getting_started');
+  });
+
+  it('replaces the summary instruction with getting-started guidance for an empty catalog', async () => {
+    const facade = {
+      summarizeDataCatalog: jest.fn().mockResolvedValue({
+        projectId: 'project-1',
+        dataMartCount: 0,
+        topDataMartsByConnectivity: [],
+      }),
+      listDataMarts: jest.fn().mockResolvedValue({ dataMarts: [] }),
+    } as unknown as jest.Mocked<McpDataMartsFacade>;
+    const tool = new SummarizeDataCatalogTool(facade, publicOrigin, projectContext as never);
+
+    const result = await tool.handler({}, context);
+
+    expect(result.structuredContent).toMatchObject({
+      project: { id: 'project-1', title: 'Analytics' },
+      project_id: 'project-1',
+      data_mart_count: 0,
+      top_data_marts_by_connectivity: [],
+      getting_started: {
+        reason: 'no_published_data_marts',
+        can_create_data_marts: false,
+        create_data_mart_url: 'https://app.owox.com/ui/project-1/data-marts/create',
+        draft_data_marts: [],
+      },
+      _instruction: expect.stringContaining('Follow getting_started.instructions'),
+    });
+    expect(result.structuredContent?._instruction).not.toContain('suggest 4-6');
+    expect(facade.listDataMarts).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'project-1', status: 'draft' })
+    );
   });
 
   it('describes read-only summary access without promising rows or freshness', () => {
@@ -150,6 +183,7 @@ describe('SummarizeDataCatalogTool', () => {
         project_id: expect.any(Object),
         data_mart_count: expect.any(Object),
         top_data_marts_by_connectivity: expect.any(Object),
+        getting_started: expect.any(Object),
         _instruction: expect.any(Object),
       }),
       annotations: {

--- a/apps/backend/src/ee/mcp/tools/summarize-data-catalog.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/summarize-data-catalog.tool.ts
@@ -13,6 +13,7 @@ import {
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import type { McpToolDefinition, McpToolResult } from './mcp-tool.definition';
 import { buildDataMartUiPath } from './data-mart-ui-path';
+import { buildGettingStarted, gettingStartedSchema } from './mcp-getting-started.util';
 import { tryGetMcpProjectSummary } from './mcp-project-summary.util';
 import { joinPublicOrigin } from './mcp-public-url.util';
 
@@ -21,6 +22,9 @@ type SummarizeDataCatalogInput = z.infer<typeof inputSchema>;
 
 const INSTRUCTION =
   'You have received a high-level summary of the published Data Mart catalog available to this MCP connection. Summarize the business areas covered by the listed Data Marts and suggest 4-6 concrete example prompts the user could ask. Do not claim access to data rows, sample values, row counts, or freshness details.';
+
+const EMPTY_CATALOG_INSTRUCTION =
+  'The published Data Mart catalog available to this MCP connection is empty, so there are no business areas to summarize and no example prompts to suggest. Follow getting_started.instructions: explain what a Data Mart is and what the user has to do next in the OWOX Data Marts web app.';
 
 @Injectable()
 export class SummarizeDataCatalogTool implements McpToolDefinition<SummarizeDataCatalogInput> {
@@ -44,6 +48,11 @@ export class SummarizeDataCatalogTool implements McpToolDefinition<SummarizeData
         updated_at: z.string(),
       })
     ),
+    getting_started: gettingStartedSchema
+      .optional()
+      .describe(
+        'Present only when the catalog is empty: links and next steps for creating the first data mart.'
+      ),
     _instruction: z.string(),
   };
   readonly annotations = {
@@ -78,6 +87,10 @@ export class SummarizeDataCatalogTool implements McpToolDefinition<SummarizeData
       tryGetMcpProjectSummary(this.projectContext, context),
     ]);
     const publicOrigin = this.publicOriginService.getPublicOrigin();
+    const gettingStarted =
+      result.dataMartCount === 0
+        ? await buildGettingStarted({ dataMarts: this.dataMarts, publicOrigin }, context)
+        : undefined;
     const structuredContent = {
       ...(projectContext ? { project: projectContext } : {}),
       project_id: result.projectId,
@@ -92,7 +105,8 @@ export class SummarizeDataCatalogTool implements McpToolDefinition<SummarizeData
         triggers_count: dataMart.triggersCount,
         updated_at: dataMart.updatedAt,
       })),
-      _instruction: INSTRUCTION,
+      ...(gettingStarted ? { getting_started: gettingStarted } : {}),
+      _instruction: gettingStarted ? EMPTY_CATALOG_INSTRUCTION : INSTRUCTION,
     };
 
     return {

--- a/docs/getting-started/setup-guide/mcp.md
+++ b/docs/getting-started/setup-guide/mcp.md
@@ -6,7 +6,7 @@ Use the MCP server to explore your [data marts](../core-concepts.md) in plain la
 
 ## Prerequisites
 
-- An active OWOX Data Marts project with at least one data mart. New to Data Marts? See how to create a [connector-based](./connector-data-mart.md) or [SQL-based](./sql-data-mart.md) Data Mart.
+- An active OWOX Data Marts project with at least one published data mart. New to Data Marts? See how to create a [connector-based](./connector-data-mart.md) or [SQL-based](./sql-data-mart.md) Data Mart. You can connect before creating one — the assistant then explains what a data mart is and where to create it (see [The assistant says there are no data marts](#the-assistant-says-there-are-no-data-marts)).
 - One of the supported clients: Claude Desktop or Claude web (claude.ai) — the recommended way to connect — or ChatGPT. Any other client that supports the MCP Streamable HTTP transport with OAuth 2.0 will also work.
 - A client plan that allows MCP connectors. Adding an MCP server like OWOX may require a paid plan in Claude or ChatGPT. Check your client's current plan requirements.
 
@@ -110,12 +110,13 @@ Returns a high-level summary of the published data mart catalog available to thi
 
 **Returns:**
 
-| Field                            | Description                                                                  |
-| -------------------------------- | ---------------------------------------------------------------------------- |
-| `project_id`                     | Project identifier                                                           |
-| `data_mart_count`                | Number of published data marts visible to you                                |
-| `top_data_marts_by_connectivity` | Data marts ranked by configured relationship connectivity                    |
-| `_instruction`                   | Internal guidance for the assistant on how to summarize the returned catalog |
+| Field                            | Description                                                                                                                                                                           |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_id`                     | Project identifier                                                                                                                                                                    |
+| `data_mart_count`                | Number of published data marts visible to you                                                                                                                                         |
+| `top_data_marts_by_connectivity` | Data marts ranked by configured relationship connectivity                                                                                                                             |
+| `getting_started`                | Only when the catalog is empty: links and next steps for creating the first data mart (see [The assistant says there are no data marts](#the-assistant-says-there-are-no-data-marts)) |
+| `_instruction`                   | Internal guidance for the assistant on how to summarize the returned catalog                                                                                                          |
 
 Each `top_data_marts_by_connectivity` item includes `id`, `title`, `description`, `url`, `relationship_count`, `reports_count`, `triggers_count`, and `updated_at`.
 
@@ -164,6 +165,8 @@ Use this tool to discover available data marts before running queries or buildin
 
 The response also includes `project.id` and `project.title`, so the assistant can state which project its discovery results belong to.
 
+When you see no published data mart, the response also includes `getting_started` — links and next steps for creating the first one (see [The assistant says there are no data marts](#the-assistant-says-there-are-no-data-marts)).
+
 The list reflects your access: it includes only the data marts your [project role](../../project/roles-and-permissions.md) permits you to see. If a data mart you expect is missing, check your role in that project.
 
 ### `get_relevant_data_marts_by_prompt`
@@ -189,7 +192,7 @@ Finds the data marts most relevant to a natural-language question, ranked by rel
 
 The response also includes `project.id` and `project.title`.
 
-Only non-draft data marts visible to your [project role](../../project/roles-and-permissions.md) are returned.
+Only non-draft data marts visible to your [project role](../../project/roles-and-permissions.md) are returned. An empty result usually means nothing matched the prompt; when you see no published data mart at all, the response also includes `getting_started` (see [The assistant says there are no data marts](#the-assistant-says-there-are-no-data-marts)) so the assistant explains what to do instead of rephrasing the search.
 
 ### `get_data_mart_details_by_id`
 
@@ -618,6 +621,26 @@ The MCP server rejects a request with `401` in these cases. Your AI client may s
 ### A tool reports `Missing MCP scope: mcp:write`
 
 The token does not include the write scope required for tools that create, change, run, or bill something. Disconnect and reconnect the MCP server, then approve the requested scopes during authorization. If your client lets you choose scopes manually, include both `mcp:read` and `mcp:write`.
+
+### The assistant says there are no data marts
+
+MCP works only with **published** data marts that your [project role](../../project/roles-and-permissions.md) lets you see. When there is none, `list_data_marts`, `get_relevant_data_marts_by_prompt`, and `summarize_data_catalog` return `getting_started` instead of a bare empty list, and the assistant explains what a data mart is and what to do next rather than retrying the search or querying data:
+
+| Field                   | Description                                                                                                                                          |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `can_create_data_marts` | Whether your role may create data marts (Project Admin or Technical User)                                                                            |
+| `create_data_mart_url`  | The page in OWOX Data Marts where a new data mart is created                                                                                         |
+| `data_marts_url`        | The Data Marts list of the connected project                                                                                                         |
+| `guides`                | Links to the [core concepts](../core-concepts.md), [connector-based](./connector-data-mart.md), and [SQL-based](./sql-data-mart.md) data mart guides |
+| `draft_data_marts`      | Draft data marts you can see; they become available to MCP once published                                                                            |
+| `instructions`          | Internal guidance the assistant relays to you                                                                                                        |
+
+A data mart cannot be created or published through MCP. To continue:
+
+- **Project Admin or Technical User:** open `create_data_mart_url`, connect a data source or define the data mart from SQL, a table, or a view on a connected storage, then save and **Publish** it. If the assistant lists drafts, open each one, finish its setup, and publish it.
+- **Business User:** ask a Project Admin or a Technical User of the project to create and publish a data mart and share it with you for reporting.
+
+Then ask the assistant again — no reconnection is needed.
 
 ### The wrong project is connected
 


### PR DESCRIPTION
## Why

A user who connects the MCP server before their project has a published data mart gets nothing useful. `list_data_marts` and `get_relevant_data_marts_by_prompt` return a bare `data_marts: []`, `summarize_data_catalog` returns `data_mart_count: 0` together with an instruction to "summarize the business areas and suggest example prompts", and the system instructions tell the assistant to rephrase and search again. The assistant ends up saying "no data found" after a few futile searches, and the user never learns what a data mart is, where to create one, or that a draft has to be published first. A data mart cannot be created or published through MCP, so the tools have to point the user to the web app.

## What changes

**`getting_started` in the discovery tools** (new `mcp-getting-started.util.ts`)
- `list_data_marts`, `get_relevant_data_marts_by_prompt`, and `summarize_data_catalog` attach `getting_started` when the user sees no published data mart: `can_create_data_marts` (derived from the token roles: admin and editor may create), `create_data_mart_url` and `data_marts_url` built on `PUBLIC_ORIGIN`, `guides` (core concepts, connector-based, SQL-based), `draft_data_marts` the user can see with their pages, and `instructions` the assistant relays. The instructions are role-aware: creators are walked through create → set up → publish (and told to publish listed drafts); business users are told to ask a Project Admin or Technical User to create, publish, and share one.
- `get_relevant_data_marts_by_prompt` only guides when the published catalog is actually empty — an ordinary miss still asks the assistant to rephrase. `list_data_marts` with `status=draft` guides only when no published data mart exists either.
- `summarize_data_catalog` replaces its summary `_instruction` with an empty-catalog one instead of asking for business areas and example prompts.
- The draft lookup is best-effort: if it fails, the links and steps are still returned (warning logged), mirroring how the optional project summary is handled.
- `getting_started` is declared in each tool's `outputSchema`, since the SDK validates `structuredContent` against it.

**System instructions**
- Step 2 of the analytical flow now stops rephrasing when `getting_started` is present, and a new "Empty project" section tells the assistant to relay the guidance and not call `get_data_mart_details_by_id`, `query_data_mart`, or any report or schedule tool until a published data mart exists.

**Docs and changeset**
- `docs/getting-started/setup-guide/mcp.md`: new troubleshooting entry "The assistant says there are no data marts" with the `getting_started` fields and role-specific next steps; the three tool sections and the prerequisites link to it.
- One `'owox': minor` changeset.

Out of scope, on purpose: creating data marts through MCP, changes to `get_project_context`, and the not-found handling of `get_data_mart_details_by_id`.

## Verification

- `nest build` (CI-equivalent) passes.
- Targeted specs pass (35 tests across 5 suites): the new util spec (creator vs business user, admin, drafts and their wording, failed draft lookup, `resolveGettingStarted` both ways), the three tool specs (empty published list with drafts, empty draft list with a published data mart, search miss with a non-empty catalog, search hit never touches the catalog, empty-catalog summary instruction), and the instructions spec.
- Prettier, ESLint, and markdownlint are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
