### PR TITLE
docs(facebook): explain app rate limits and label retry settings

### DIFF
--- a/.changeset/6902-retry-settings-labels.md
+++ b/.changeset/6902-retry-settings-labels.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Labeled retry settings in connector Advanced settings
+
+Every connector's **Advanced settings** form now shows **Max Fetch Retries** and **Initial Retry Delay (ms)** instead of raw keys. The hints state that the delay is in milliseconds and that the retries value counts total attempts, including the first request. This prevents a delay of `5` being read as five seconds when it means five milliseconds.
+
+The Facebook Ads troubleshooting guide now explains Meta's Ads Insights rate limit (code 4, subcode 1504022), the ad-account score limit (code 17, subcode 2446079), and how to adjust these settings after a rate limit error.

--- a/packages/connectors/src/Core/AbstractSource.js
+++ b/packages/connectors/src/Core/AbstractSource.js
@@ -23,11 +23,15 @@ var AbstractSource = class AbstractSource {
         MaxFetchRetries: {
           requiredType: "number",
           default: 3,
+          label: "Max Fetch Retries",
+          description: "Number of attempts for a failed API request before the run stops",
           attributes: [CONFIG_ATTRIBUTES.ADVANCED]
         },
         InitialRetryDelay: {
           requiredType: "number",
           default: 5000,
+          label: "Initial Retry Delay",
+          description: "Delay before the first retry in milliseconds. Each retry doubles the delay",
           attributes: [CONFIG_ATTRIBUTES.ADVANCED]
         }
       });

--- a/packages/connectors/src/Core/AbstractSource.js
+++ b/packages/connectors/src/Core/AbstractSource.js
@@ -24,13 +24,13 @@ var AbstractSource = class AbstractSource {
           requiredType: "number",
           default: 3,
           label: "Max Fetch Retries",
-          description: "Number of attempts for a failed API request before the run stops",
+          description: "Total attempts for a failed API request, including the first request, before the run stops",
           attributes: [CONFIG_ATTRIBUTES.ADVANCED]
         },
         InitialRetryDelay: {
           requiredType: "number",
           default: 5000,
-          label: "Initial Retry Delay",
+          label: "Initial Retry Delay (ms)",
           description: "Delay before the first retry in milliseconds. Each retry doubles the delay",
           attributes: [CONFIG_ATTRIBUTES.ADVANCED]
         }

--- a/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
+++ b/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
@@ -27,7 +27,8 @@ If these checks look correct, match the **Run history** error with the cases bel
 | Account does not exist, account cannot load, or `Unsupported get request` | The Account ID is wrong. It may include `act_`, or the user lacks access. | Enter the numeric Account ID only. Remove `act_`. Confirm Admin, Advertiser, or Analyst access. |
 | Import fails for only one account in a multi-account setup | One Account ID is invalid, or the user lacks access to that account. | Run the Data Mart with one Account ID at a time. Find the failing account. Then fix the ID or Meta access. |
 | `There have been too many calls to this ad-account` (code `80004`, subcode `2446079`) | Meta throttled ads management calls for one ad account. Every account has an hourly call budget. | See [Ad Account Rate Limits](#ad-account-rate-limits). |
-| Rate limit errors, `Application request limit reached`, or `User request limit reached` | Meta throttled requests for the app, user, or ad account. | Wait and rerun later. If the error repeats, reduce run frequency, date range, selected accounts, fields, or breakdowns. |
+| `Application request limit reached` (code `4`, subcode `1504022`) | Meta throttled calls for your Meta app. All Data Marts and tools that use the same app share one hourly budget. | See [App Rate Limits](#app-rate-limits). |
+| `User request limit reached` (code `17`) | Meta throttled calls for the Facebook user who authorized the connection. | Wait one hour. Then follow the steps in [App Rate Limits](#app-rate-limits). |
 | `Please reduce the amount of data you're asking for, then retry your request` or request timeout errors | The request asks Meta for too much data. | Reduce the date range, fields, or breakdowns. Then lower **API Page Limit** in **Advanced settings** and rerun. |
 | Empty results with no obvious API error | The date range has no delivery data. The selected fields may have no values. | Check the same date range in Meta Ads Manager. Then try **Ad Account Insights** with spend, clicks, and impressions. |
 
@@ -50,6 +51,25 @@ After a rate limit error, do this:
 4. Split ad accounts across several Data Marts. Stagger the schedules by an hour.
 5. Lower the run frequency. Catalog endpoints such as Ad Creatives change slowly.
 6. Apply for Advanced Access in your Meta app. This raises the budget to 100 000 calls.
+
+Meta explains the full model in [Marketing API rate limiting](https://developers.facebook.com/docs/marketing-api/overview/rate-limiting).
+
+## App Rate Limits
+
+Meta counts API calls per Meta app in a rolling one-hour window. This budget is separate from the ad account budget above.
+Every Data Mart, script, or third-party tool that uses the same Meta app draws from it.
+
+A run that hits this limit keeps every row it already saved. Incremental mode resumes from the last saved date on the next run.
+
+After an app rate limit error, do this:
+
+1. Wait one hour. Then rerun the Data Mart from **Run history**.
+2. Open **Advanced settings**. Set **Initial Retry Delay** to `60000` and **Max Fetch Retries** to `5`.
+   OWOX reads the delay in milliseconds. A value of `5` means five milliseconds, so retries fire before Meta resets.
+3. Lower **Reimport Lookback Window**. Each extra day multiplies the call count by the number of accounts.
+4. Split ad accounts across several Data Marts. Stagger their schedules by at least one hour.
+5. Move other Data Marts or tools that use the same Meta app to a different time slot.
+6. Apply for Advanced Access in your Meta app. This raises the hourly budget.
 
 Meta explains the full model in [Marketing API rate limiting](https://developers.facebook.com/docs/marketing-api/overview/rate-limiting).
 

--- a/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
+++ b/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
@@ -27,8 +27,8 @@ If these checks look correct, match the **Run history** error with the cases bel
 | Account does not exist, account cannot load, or `Unsupported get request` | The Account ID is wrong. It may include `act_`, or the user lacks access. | Enter the numeric Account ID only. Remove `act_`. Confirm Admin, Advertiser, or Analyst access. |
 | Import fails for only one account in a multi-account setup | One Account ID is invalid, or the user lacks access to that account. | Run the Data Mart with one Account ID at a time. Find the failing account. Then fix the ID or Meta access. |
 | `There have been too many calls to this ad-account` (code `80004`, subcode `2446079`) | Meta throttled ads management calls for one ad account. Every account has an hourly call budget. | See [Ad Account Rate Limits](#ad-account-rate-limits). |
-| `Application request limit reached` (code `4`, subcode `1504022`) | Meta throttled calls for your Meta app. All Data Marts and tools that use the same app share one hourly budget. | See [App Rate Limits](#app-rate-limits). |
-| `User request limit reached` (code `17`) | Meta throttled calls for the Facebook user who authorized the connection. | Wait one hour. Then follow the steps in [App Rate Limits](#app-rate-limits). |
+| `Application request limit reached` or `There have been too many calls from this app` (code `4`, subcode `1504022`) | Meta throttled Ads Insights calls. Meta counts this load per app and per ad account. | See [App Rate Limits](#app-rate-limits). |
+| `User request limit reached` (code `17`, subcode `2446079`) | Meta throttled API calls for one ad account. Meta scores each call and blocks the account for a few minutes. | Wait five minutes, then rerun. If it repeats, see [Ad Account Rate Limits](#ad-account-rate-limits). |
 | `Please reduce the amount of data you're asking for, then retry your request` or request timeout errors | The request asks Meta for too much data. | Reduce the date range, fields, or breakdowns. Then lower **API Page Limit** in **Advanced settings** and rerun. |
 | Empty results with no obvious API error | The date range has no delivery data. The selected fields may have no values. | Check the same date range in Meta Ads Manager. Then try **Ad Account Insights** with spend, clicks, and impressions. |
 
@@ -56,21 +56,24 @@ Meta explains the full model in [Marketing API rate limiting](https://developers
 
 ## App Rate Limits
 
-Meta counts API calls per Meta app in a rolling one-hour window. This budget is separate from the ad account budget above.
-Every Data Mart, script, or third-party tool that uses the same Meta app draws from it.
+Meta throttles Ads Insights calls per Meta app and per ad account. Meta sizes this budget by query load, not by a fixed call count.
+Wide date ranges, many fields, breakdowns, and many ad accounts all raise the load.
+Every Data Mart, script, or third-party tool that uses the same Meta app draws from the app budget.
 
 A run that hits this limit keeps every row it already saved. Incremental mode resumes from the last saved date on the next run.
 
 After an app rate limit error, do this:
 
-1. Wait one hour. Then rerun the Data Mart from **Run history**.
-2. Open **Advanced settings**. Set **Initial Retry Delay** to `60000` and **Max Fetch Retries** to `5`.
-   OWOX reads the delay in milliseconds. A value of `5` means five milliseconds, so retries fire before Meta resets.
-3. Lower **Reimport Lookback Window**. Each extra day multiplies the call count by the number of accounts.
-4. Split ad accounts across several Data Marts. Stagger their schedules by at least one hour.
-5. Move other Data Marts or tools that use the same Meta app to a different time slot.
+1. Wait one hour. Then start a **Manual Run** from the Data Mart.
+2. Open **Advanced settings**. Set **Initial Retry Delay (ms)** to `60000` and **Max Fetch Retries** to `5`.
+   The waits double each time, so the retries span roughly 15 minutes. This rides out a short throttle, not a full block.
+   The value is in milliseconds. A value of `5` means five milliseconds, so retries fire before Meta resets.
+3. Reduce insights load. Remove fields you do not report on. Drop breakdowns you do not need.
+4. Lower **Reimport Lookback Window**. Each extra day multiplies the call count by the number of accounts.
+5. Split ad accounts across several Data Marts. Stagger their schedules by at least one hour.
+6. Move other Data Marts or tools that use the same Meta app to a different time slot.
 
-Meta explains the full model in [Marketing API rate limiting](https://developers.facebook.com/docs/marketing-api/overview/rate-limiting).
+Meta explains the full model in [Marketing API rate limiting](https://developers.facebook.com/docs/marketing-api/overview/rate-limiting) and [Insights API best practices](https://developers.facebook.com/docs/marketing-api/insights/best-practices/).
 
 ## Still Blocked
 

--- a/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
+++ b/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
@@ -69,7 +69,6 @@ After an app rate limit error, do this:
 3. Lower **Reimport Lookback Window**. Each extra day multiplies the call count by the number of accounts.
 4. Split ad accounts across several Data Marts. Stagger their schedules by at least one hour.
 5. Move other Data Marts or tools that use the same Meta app to a different time slot.
-6. Apply for Advanced Access in your Meta app. This raises the hourly budget.
 
 Meta explains the full model in [Marketing API rate limiting](https://developers.facebook.com/docs/marketing-api/overview/rate-limiting).
 


### PR DESCRIPTION
# Problem

A Facebook Ads Data Mart run failed with `Application request limit reached` (Meta error code 4, subcode 1504022) after importing 16 of 17 ad accounts. The troubleshooting page only said "wait and rerun later" and did not distinguish this Ads Insights throttle from the per-ad-account limits already documented, so users could not tell which budget they hit or which OWOX settings to change. The run also retried three times within one second because `InitialRetryDelay` was set to `5`: the field had no label or description in the Advanced settings form, so nothing told users the value is in milliseconds.

# Solution

- Split the generic rate-limit row in `TROUBLESHOOTING.md` into two rows with Meta error codes. Code 4 / 1504022 is Meta's Ads Insights throttle, counted per app and per ad account by query load. Code 17 / 2446079 is the ad-account score limit with a short block, so it now points to the existing **Ad Account Rate Limits** section.
- Added an **App Rate Limits** section that explains the insights budget, states that partial-run rows are kept and incremental mode resumes, and lists six remediation steps in priority order. It also states that the recommended retry settings span roughly 15 minutes, which rides out a short throttle but not a full block.
- Added `label` and `description` to `MaxFetchRetries` and `InitialRetryDelay` in `AbstractSource.js`. The backend maps `label` to the form field title, so every connector's Advanced settings now shows **Max Fetch Retries** and **Initial Retry Delay (ms)**. The unit is in the label because the form renders `description` only as a hover tooltip. The description clarifies that the retries value counts total attempts, including the first request.
- Added a changeset because the label change alters the shipped `@owox/connectors` package and is visible in every connector's form.

# Changes

- Replaced the single rate-limit row with separate rows for `Application request limit reached` / `There have been too many calls from this app` (code 4, subcode 1504022, Ads Insights throttle) and `User request limit reached` (code 17, subcode 2446079, ad-account score limit)
- Added an **App Rate Limits** section with six steps: wait and start a Manual Run, raise retry delay and attempts, reduce insights fields and breakdowns, lower Reimport Lookback Window, split accounts across Data Marts, stagger other consumers of the same Meta app
- Linked Meta's Marketing API rate limiting and Insights API best-practices pages from the new section
- Added `label: "Max Fetch Retries"` with a description stating the value counts total attempts including the first request
- Added `label: "Initial Retry Delay (ms)"` with a description stating the millisecond unit and exponential doubling
- Added changeset `6902-retry-settings-labels.md` (`'owox': minor`)
