### PR TITLE
fix: scope automatic project redirects to users

### DIFF
--- a/.changeset/6894-user-bound-project-redirect.md
+++ b/.changeset/6894-user-bound-project-redirect.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Keep automatic project redirects scoped to the signed-in user
+
+OWOX Data Marts no longer carries an automatically remembered project into a session for a different user. After switching accounts during sign-in, users continue with a project available to the newly authenticated account instead of being sent to request access for the previous account's project.

--- a/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
+++ b/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
@@ -480,12 +480,7 @@ export class OwoxBetterAuthIdp implements IdpProvider {
     if (stateManager.hasMismatch()) {
       this.logger.warn('State mismatch detected during sign-in', { path: req.path, queryState });
       clearAuthFlowCookies(res, req);
-      return this.redirectToPlatform(
-        req,
-        res,
-        this.config.idpOwox.idpConfig.platformSignInUrl,
-        true
-      );
+      return this.redirectToPlatform(req, res, this.config.idpOwox.idpConfig.platformSignInUrl);
     }
 
     if (!queryState) {
@@ -603,16 +598,15 @@ export class OwoxBetterAuthIdp implements IdpProvider {
     params: AuthFlowParams,
     authenticatedUserId?: string
   ): AuthFlowParams {
-    if (
-      !params.projectRedirectUserId ||
-      !authenticatedUserId ||
-      params.projectRedirectUserId === authenticatedUserId
-    ) {
+    if (!params.projectRedirectUserId) {
+      return params;
+    }
+    if (authenticatedUserId && params.projectRedirectUserId === authenticatedUserId) {
       return params;
     }
 
-    this.logger.info('Discarding project redirect owned by a different user', {
-      authenticatedUserId,
+    this.logger.info('Discarding user-bound project redirect', {
+      reason: authenticatedUserId ? 'different-user' : 'unknown-user',
     });
     return {
       ...params,
@@ -875,32 +869,33 @@ export class OwoxBetterAuthIdp implements IdpProvider {
   private async redirectToPlatform(
     req: e.Request,
     res: e.Response,
-    authUrl: string,
-    bindGeneratedProjectRedirectToUser = false
+    authUrl: string
   ): Promise<void | e.Response> {
     const params = extractAuthFlowParams(req);
-    const createsProjectRedirect = Boolean(params.projectId && !params.appRedirectTo);
+    const generatedProjectId = params.projectId && !params.appRedirectTo ? params.projectId : null;
     let projectRedirectUserId = params.projectRedirectUserId;
-    if (createsProjectRedirect && bindGeneratedProjectRedirectToUser) {
-      const refreshToken = extractRefreshToken(req);
-      if (refreshToken) {
-        try {
-          const payload = await this.tokenFacade.parseToken(refreshToken);
-          projectRedirectUserId = payload?.userId;
-        } catch (error: unknown) {
-          this.logger.warn(
-            'Failed to bind generated project redirect to the current user',
-            { path: req.path },
-            error instanceof Error ? error : undefined
-          );
-        }
+    let preserveGeneratedProjectRedirect = true;
+    const refreshToken = generatedProjectId ? extractRefreshToken(req) : undefined;
+    if (refreshToken) {
+      const payload = await this.tokenFacade.parseToken(refreshToken);
+      if (payload) {
+        projectRedirectUserId = payload.userId;
+      } else {
+        preserveGeneratedProjectRedirect = false;
+        projectRedirectUserId = undefined;
+        this.logger.warn(
+          'Discarding unbound project redirect because the current user is unknown',
+          { path: req.path }
+        );
       }
     }
     const enhancedParams = {
       ...params,
+      projectId:
+        generatedProjectId && !preserveGeneratedProjectRedirect ? undefined : params.projectId,
       appRedirectTo:
-        params.projectId && !params.appRedirectTo
-          ? `/auth/idp-start?projectId=${encodeURIComponent(params.projectId)}`
+        generatedProjectId && preserveGeneratedProjectRedirect
+          ? `/auth/idp-start?projectId=${encodeURIComponent(generatedProjectId)}`
           : params.appRedirectTo,
       projectRedirectUserId,
     };

--- a/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
+++ b/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
@@ -398,18 +398,22 @@ export class OwoxBetterAuthIdp implements IdpProvider {
         );
 
         const callbackAuthFlowParams = response.authFlowParams ?? extractAuthFlowParams(req);
-        const redirectTarget = this.resolveExistingRefreshRedirect(callbackAuthFlowParams);
+        const payload = await this.tokenFacade.parseToken(response.accessToken);
+        const resolvedAuthFlowParams = this.resolveUserBoundProjectRedirect(
+          callbackAuthFlowParams,
+          payload?.userId
+        );
+        const redirectTarget = this.resolveExistingRefreshRedirect(resolvedAuthFlowParams);
         this.logger.info('Completed IDP callback', {
           path: req.path,
           redirectTarget,
-          redirectTo: callbackAuthFlowParams.redirectTo,
-          appRedirectTo: callbackAuthFlowParams.appRedirectTo,
+          redirectTo: resolvedAuthFlowParams.redirectTo,
+          appRedirectTo: resolvedAuthFlowParams.appRedirectTo,
         });
 
         clearAuthFlowCookies(res, req);
 
         // Check if onboarding questionnaire should be shown
-        const payload = await this.tokenFacade.parseToken(response.accessToken);
         if (payload) {
           try {
             await this.onboardingService.evaluateAndSetOnboardingStatus(
@@ -476,7 +480,12 @@ export class OwoxBetterAuthIdp implements IdpProvider {
     if (stateManager.hasMismatch()) {
       this.logger.warn('State mismatch detected during sign-in', { path: req.path, queryState });
       clearAuthFlowCookies(res, req);
-      return this.redirectToPlatform(req, res, this.config.idpOwox.idpConfig.platformSignInUrl);
+      return this.redirectToPlatform(
+        req,
+        res,
+        this.config.idpOwox.idpConfig.platformSignInUrl,
+        true
+      );
     }
 
     if (!queryState) {
@@ -588,6 +597,28 @@ export class OwoxBetterAuthIdp implements IdpProvider {
       sanitizeRedirectParam(params.appRedirectTo, allowedRedirectOrigins) ??
       '/'
     );
+  }
+
+  private resolveUserBoundProjectRedirect(
+    params: AuthFlowParams,
+    authenticatedUserId?: string
+  ): AuthFlowParams {
+    if (
+      !params.projectRedirectUserId ||
+      !authenticatedUserId ||
+      params.projectRedirectUserId === authenticatedUserId
+    ) {
+      return params;
+    }
+
+    this.logger.info('Discarding project redirect owned by a different user', {
+      authenticatedUserId,
+    });
+    return {
+      ...params,
+      appRedirectTo: undefined,
+      projectRedirectUserId: undefined,
+    };
   }
 
   async signUpMiddleware(
@@ -844,15 +875,34 @@ export class OwoxBetterAuthIdp implements IdpProvider {
   private async redirectToPlatform(
     req: e.Request,
     res: e.Response,
-    authUrl: string
+    authUrl: string,
+    bindGeneratedProjectRedirectToUser = false
   ): Promise<void | e.Response> {
     const params = extractAuthFlowParams(req);
+    const createsProjectRedirect = Boolean(params.projectId && !params.appRedirectTo);
+    let projectRedirectUserId = params.projectRedirectUserId;
+    if (createsProjectRedirect && bindGeneratedProjectRedirectToUser) {
+      const refreshToken = extractRefreshToken(req);
+      if (refreshToken) {
+        try {
+          const payload = await this.tokenFacade.parseToken(refreshToken);
+          projectRedirectUserId = payload?.userId;
+        } catch (error: unknown) {
+          this.logger.warn(
+            'Failed to bind generated project redirect to the current user',
+            { path: req.path },
+            error instanceof Error ? error : undefined
+          );
+        }
+      }
+    }
     const enhancedParams = {
       ...params,
       appRedirectTo:
         params.projectId && !params.appRedirectTo
           ? `/auth/idp-start?projectId=${encodeURIComponent(params.projectId)}`
           : params.appRedirectTo,
+      projectRedirectUserId,
     };
     persistAuthFlowParams(req, res, enhancedParams);
     const platformUrl = buildPlatformEntryUrl({

--- a/packages/idp-owox-better-auth/src/owox-better-auth-idp.user-bound-redirect.test.ts
+++ b/packages/idp-owox-better-auth/src/owox-better-auth-idp.user-bound-redirect.test.ts
@@ -6,7 +6,7 @@ import { OwoxBetterAuthIdp } from './owox-better-auth-idp.js';
 type RouteHandler = (req: Request, res: Response) => Promise<void>;
 
 function createCallbackProvider(params: {
-  authenticatedUserId: string;
+  authenticatedUserId?: string;
   appRedirectTo: string;
   projectRedirectUserId?: string;
 }): { provider: OwoxBetterAuthIdp; callback: RouteHandler } {
@@ -26,11 +26,15 @@ function createCallbackProvider(params: {
       },
     }),
     setTokenToCookie: jest.fn(),
-    parseToken: jest.fn().mockResolvedValue({
-      userId: params.authenticatedUserId,
-      projectId: 'current-project',
-      email: 'user@example.com',
-    }),
+    parseToken: jest.fn().mockResolvedValue(
+      params.authenticatedUserId
+        ? {
+            userId: params.authenticatedUserId,
+            projectId: 'current-project',
+            email: 'user@example.com',
+          }
+        : null
+    ),
   };
   const provider = Object.assign(Object.create(OwoxBetterAuthIdp.prototype), {
     betterAuthProxyHandler: { setupBetterAuthHandler: jest.fn() },
@@ -135,11 +139,115 @@ describe('OwoxBetterAuthIdp user-bound project redirects', () => {
     });
   });
 
+  it('binds a generated project redirect from the sign-up fallback', async () => {
+    const tokenFacade = {
+      parseToken: jest.fn().mockResolvedValue({
+        userId: 'current-user',
+        projectId: 'current-project',
+      }),
+    };
+    const provider = Object.assign(Object.create(OwoxBetterAuthIdp.prototype), {
+      tokenFacade,
+      config: {
+        idpOwox: {
+          idpConfig: {
+            platformSignUpUrl: 'https://platform.test/auth/sign-up',
+            allowedRedirectOrigins: [],
+          },
+        },
+      },
+      logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      },
+    }) as OwoxBetterAuthIdp;
+    const persistedParams = encodeURIComponent(JSON.stringify({ projectId: 'current-project' }));
+    const request = {
+      path: `${AUTH_BASE_PATH}/sign-up`,
+      protocol: 'https',
+      hostname: 'app.test',
+      headers: {
+        cookie: `idp-owox-params=${persistedParams}; refreshToken=current-refresh-token`,
+      },
+      query: {},
+    } as unknown as Request;
+    const response = createResponse();
+
+    await provider.signUpMiddleware(request, response, jest.fn());
+
+    expect(tokenFacade.parseToken).toHaveBeenCalledWith('current-refresh-token');
+    const paramsCookieCall = (response.cookie as jest.Mock).mock.calls.find(
+      call => call[0] === 'idp-owox-params'
+    );
+    const params = JSON.parse(decodeURIComponent(paramsCookieCall?.[1] as string));
+    expect(params).toMatchObject({
+      appRedirectTo: '/auth/idp-start?projectId=current-project',
+      projectRedirectUserId: 'current-user',
+    });
+  });
+
+  it('discards a generated project redirect when its user cannot be resolved', async () => {
+    const tokenFacade = {
+      parseToken: jest.fn().mockResolvedValue(null),
+    };
+    const provider = Object.assign(Object.create(OwoxBetterAuthIdp.prototype), {
+      tokenFacade,
+      config: {
+        idpOwox: {
+          idpConfig: {
+            platformSignInUrl: 'https://platform.test/auth/sign-in',
+            allowedRedirectOrigins: [],
+          },
+        },
+      },
+      logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      },
+    }) as OwoxBetterAuthIdp;
+    const persistedParams = encodeURIComponent(JSON.stringify({ projectId: 'previous-project' }));
+    const request = {
+      path: `${AUTH_BASE_PATH}/sign-in`,
+      protocol: 'https',
+      hostname: 'app.test',
+      headers: {
+        cookie: `idp-owox-state=old-state; idp-owox-params=${persistedParams}; refreshToken=unverifiable-refresh-token`,
+      },
+      query: { state: 'new-state' },
+    } as unknown as Request;
+    const response = createResponse();
+
+    await provider.signInMiddleware(request, response, jest.fn());
+
+    const redirectUrl = (response.redirect as jest.Mock).mock.calls[0]?.[0] as string;
+    expect(redirectUrl).not.toContain('projectId');
+    expect(redirectUrl).not.toContain('app-redirect-to');
+    expect(response.cookie).not.toHaveBeenCalledWith(
+      'idp-owox-params',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
   it('discards an automatic project redirect after a different user signs in', async () => {
     const { callback } = createCallbackProvider({
       authenticatedUserId: 'credential-user',
       appRedirectTo: '/auth/idp-start?projectId=microsoft-project',
       projectRedirectUserId: 'microsoft-user',
+    });
+    const response = createResponse();
+
+    await callback(createCallbackRequest(), response);
+
+    expect(response.redirect).toHaveBeenCalledWith('/');
+  });
+
+  it('discards a bound project redirect when the callback user cannot be resolved', async () => {
+    const { callback } = createCallbackProvider({
+      appRedirectTo: '/auth/idp-start?projectId=previous-project',
+      projectRedirectUserId: 'previous-user',
     });
     const response = createResponse();
 

--- a/packages/idp-owox-better-auth/src/owox-better-auth-idp.user-bound-redirect.test.ts
+++ b/packages/idp-owox-better-auth/src/owox-better-auth-idp.user-bound-redirect.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import type { Request, Response } from 'express';
+import { AUTH_BASE_PATH } from './core/constants.js';
+import { OwoxBetterAuthIdp } from './owox-better-auth-idp.js';
+
+type RouteHandler = (req: Request, res: Response) => Promise<void>;
+
+function createCallbackProvider(params: {
+  authenticatedUserId: string;
+  appRedirectTo: string;
+  projectRedirectUserId?: string;
+}): { provider: OwoxBetterAuthIdp; callback: RouteHandler } {
+  const routes = new Map<string, RouteHandler>();
+  const app = {
+    use: jest.fn(),
+    get: jest.fn((path: string, handler: RouteHandler) => routes.set(path, handler)),
+  };
+  const tokenFacade = {
+    changeAuthCode: jest.fn().mockResolvedValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      refreshTokenExpiresIn: 3600,
+      authFlowParams: {
+        appRedirectTo: params.appRedirectTo,
+        projectRedirectUserId: params.projectRedirectUserId,
+      },
+    }),
+    setTokenToCookie: jest.fn(),
+    parseToken: jest.fn().mockResolvedValue({
+      userId: params.authenticatedUserId,
+      projectId: 'current-project',
+      email: 'user@example.com',
+    }),
+  };
+  const provider = Object.assign(Object.create(OwoxBetterAuthIdp.prototype), {
+    betterAuthProxyHandler: { setupBetterAuthHandler: jest.fn() },
+    authErrorController: { registerRoutes: jest.fn() },
+    onboardingController: { registerRoutes: jest.fn() },
+    pageController: { registerRoutes: jest.fn() },
+    passwordFlowController: { registerRoutes: jest.fn() },
+    googleSheetsAuthController: { registerRoutes: jest.fn() },
+    authFlowMiddleware: { idpStartMiddleware: jest.fn() },
+    tokenFacade,
+    userAuthInfoPersistenceService: {
+      persistAuthInfo: jest.fn().mockResolvedValue(undefined),
+    },
+    onboardingService: {
+      evaluateAndSetOnboardingStatus: jest.fn().mockResolvedValue(undefined),
+      shouldShowQuestionnaire: jest.fn().mockResolvedValue(false),
+    },
+    config: {
+      idpOwox: {
+        baseUrl: 'https://app.test',
+        idpConfig: { allowedRedirectOrigins: [] },
+      },
+    },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  }) as OwoxBetterAuthIdp;
+
+  provider.registerRoutes(app as never);
+  const callback = routes.get(`${AUTH_BASE_PATH}/callback`);
+  if (!callback) throw new Error('Callback route was not registered');
+  return { provider, callback };
+}
+
+function createCallbackRequest(): Request {
+  return {
+    path: `${AUTH_BASE_PATH}/callback`,
+    protocol: 'https',
+    hostname: 'app.test',
+    headers: { cookie: '' },
+    query: { code: 'code-1', state: 'state-1' },
+  } as unknown as Request;
+}
+
+function createResponse(): Response {
+  return {
+    cookie: jest.fn(),
+    clearCookie: jest.fn(),
+    redirect: jest.fn(),
+  } as unknown as Response;
+}
+
+describe('OwoxBetterAuthIdp user-bound project redirects', () => {
+  it('binds a generated project redirect to the user active before a state mismatch', async () => {
+    const tokenFacade = {
+      parseToken: jest.fn().mockResolvedValue({
+        userId: 'microsoft-user',
+        projectId: 'microsoft-project',
+      }),
+    };
+    const provider = Object.assign(Object.create(OwoxBetterAuthIdp.prototype), {
+      tokenFacade,
+      config: {
+        idpOwox: {
+          idpConfig: {
+            platformSignInUrl: 'https://platform.test/auth/sign-in',
+            allowedRedirectOrigins: [],
+          },
+        },
+      },
+      logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      },
+    }) as OwoxBetterAuthIdp;
+    const persistedParams = encodeURIComponent(JSON.stringify({ projectId: 'microsoft-project' }));
+    const request = {
+      path: `${AUTH_BASE_PATH}/sign-in`,
+      protocol: 'https',
+      hostname: 'app.test',
+      headers: {
+        cookie: `idp-owox-state=old-state; idp-owox-params=${persistedParams}; refreshToken=microsoft-refresh-token`,
+      },
+      query: { state: 'new-state' },
+    } as unknown as Request;
+    const response = createResponse();
+
+    await provider.signInMiddleware(request, response, jest.fn());
+
+    expect(tokenFacade.parseToken).toHaveBeenCalledWith('microsoft-refresh-token');
+    const paramsCookieCall = (response.cookie as jest.Mock).mock.calls.find(
+      call => call[0] === 'idp-owox-params'
+    );
+    expect(paramsCookieCall).toBeDefined();
+    const params = JSON.parse(decodeURIComponent(paramsCookieCall?.[1] as string));
+    expect(params).toMatchObject({
+      appRedirectTo: '/auth/idp-start?projectId=microsoft-project',
+      projectRedirectUserId: 'microsoft-user',
+    });
+  });
+
+  it('discards an automatic project redirect after a different user signs in', async () => {
+    const { callback } = createCallbackProvider({
+      authenticatedUserId: 'credential-user',
+      appRedirectTo: '/auth/idp-start?projectId=microsoft-project',
+      projectRedirectUserId: 'microsoft-user',
+    });
+    const response = createResponse();
+
+    await callback(createCallbackRequest(), response);
+
+    expect(response.redirect).toHaveBeenCalledWith('/');
+  });
+
+  it('keeps an automatic project redirect when the same user signs in', async () => {
+    const appRedirectTo = '/auth/idp-start?projectId=microsoft-project';
+    const { callback } = createCallbackProvider({
+      authenticatedUserId: 'microsoft-user',
+      appRedirectTo,
+      projectRedirectUserId: 'microsoft-user',
+    });
+    const response = createResponse();
+
+    await callback(createCallbackRequest(), response);
+
+    expect(response.redirect).toHaveBeenCalledWith(appRedirectTo);
+  });
+
+  it('keeps an explicit project redirect that has no user binding', async () => {
+    const appRedirectTo = '/auth/idp-start?projectId=shared-project';
+    const { callback } = createCallbackProvider({
+      authenticatedUserId: 'credential-user',
+      appRedirectTo,
+    });
+    const response = createResponse();
+
+    await callback(createCallbackRequest(), response);
+
+    expect(response.redirect).toHaveBeenCalledWith(appRedirectTo);
+  });
+});

--- a/packages/idp-owox-better-auth/src/utils/request-utils.test.ts
+++ b/packages/idp-owox-better-auth/src/utils/request-utils.test.ts
@@ -72,6 +72,7 @@ describe('request-utils', () => {
       JSON.stringify({
         redirectTo: '/platform',
         appRedirectTo: '/app',
+        projectRedirectUserId: 'user-1',
         source: SOURCE.PLATFORM,
         clientId: 'cid',
         codeChallenge: 'challenge',
@@ -85,6 +86,7 @@ describe('request-utils', () => {
     expect(extractAuthFlowParams(req)).toMatchObject({
       redirectTo: '/platform',
       appRedirectTo: '/app',
+      projectRedirectUserId: 'user-1',
       source: SOURCE.PLATFORM,
       clientId: 'cid',
       codeChallenge: 'challenge',
@@ -97,6 +99,7 @@ describe('request-utils', () => {
       serializeAuthFlowParams({
         redirectTo: '/platform',
         appRedirectTo: '/app',
+        projectRedirectUserId: 'user-1',
         source: SOURCE.PLATFORM,
         projectId: 'project_1',
         extraParams: { ui_locales: 'en-US' },
@@ -105,6 +108,7 @@ describe('request-utils', () => {
       JSON.stringify({
         redirectTo: '/platform',
         appRedirectTo: '/app',
+        projectRedirectUserId: 'user-1',
         source: SOURCE.PLATFORM,
         projectId: 'project_1',
         extraParams: { ui_locales: 'en-US' },
@@ -137,6 +141,7 @@ describe('request-utils', () => {
       JSON.stringify({
         redirectTo: '/oauth/authorize?client_id=stale-client&state=stale-state',
         appRedirectTo: '/oauth/authorize?client_id=stale-client&state=stale-state',
+        projectRedirectUserId: 'stale-user',
         source: SOURCE.PLATFORM,
       })
     );
@@ -152,6 +157,23 @@ describe('request-utils', () => {
       redirectTo: '/oauth/authorize?client_id=fresh-client&state=fresh-state',
       appRedirectTo: '/oauth/authorize?client_id=fresh-client&state=fresh-state',
       source: SOURCE.PLATFORM,
+    });
+    expect(extractAuthFlowParams(req).projectRedirectUserId).toBeUndefined();
+  });
+
+  it('keeps a project redirect owner when the query continues the same redirect', () => {
+    const appRedirectTo = '/auth/idp-start?projectId=project_1';
+    const payload = encodeURIComponent(
+      JSON.stringify({ appRedirectTo, projectRedirectUserId: 'user-1' })
+    );
+    const req = {
+      headers: { cookie: `idp-owox-params=${payload};` },
+      query: { 'app-redirect-to': appRedirectTo },
+    } as unknown as Request;
+
+    expect(extractAuthFlowParams(req)).toMatchObject({
+      appRedirectTo,
+      projectRedirectUserId: 'user-1',
     });
   });
 

--- a/packages/idp-owox-better-auth/src/utils/request-utils.ts
+++ b/packages/idp-owox-better-auth/src/utils/request-utils.ts
@@ -60,6 +60,7 @@ const optionalExtraParams = z.preprocess(value => {
 export const AuthFlowParamsSchema = z.object({
   redirectTo: optionalStringParam,
   appRedirectTo: optionalStringParam,
+  projectRedirectUserId: optionalStringParam,
   source: optionalStringParam,
   clientId: optionalStringParam,
   codeChallenge: optionalStringParam,
@@ -299,6 +300,11 @@ export function extractAuthFlowParams(req: Request): AuthFlowParams {
   const appRedirectTo =
     (typeof req.query?.['app-redirect-to'] === 'string' && req.query['app-redirect-to']) ||
     undefined;
+  const resolvedAppRedirectTo = appRedirectTo || cookieParams.appRedirectTo;
+  const projectRedirectUserId =
+    resolvedAppRedirectTo && resolvedAppRedirectTo === cookieParams.appRedirectTo
+      ? cookieParams.projectRedirectUserId
+      : undefined;
   const source = typeof req.query?.source === 'string' ? req.query.source : undefined;
   const clientId = typeof req.query?.clientId === 'string' ? req.query.clientId : undefined;
   const codeChallenge =
@@ -311,7 +317,8 @@ export function extractAuthFlowParams(req: Request): AuthFlowParams {
 
   return {
     redirectTo: redirectTo || cookieParams.redirectTo,
-    appRedirectTo: appRedirectTo || cookieParams.appRedirectTo,
+    appRedirectTo: resolvedAppRedirectTo,
+    projectRedirectUserId,
     source: source || cookieParams.source,
     clientId: clientId || cookieParams.clientId,
     codeChallenge: codeChallenge || cookieParams.codeChallenge,


### PR DESCRIPTION
## Summary

- bind generated project redirects to the OWOX user active before auth-flow recovery
- discard the bound redirect when the completed callback belongs to a different or unverifiable user
- preserve same-user redirects and explicit unbound project links
- add regression coverage for state mismatch, account switching, sign-up fallback, and token parsing failures

## Why

A project selected during one account session could survive a state mismatch as appRedirectTo. If another account then completed password sign-in in the same browser, ODM followed the previous account's project redirect and showed Request Access, where a new project could be created.

This change scopes only ODM-generated project redirects to their originating user. It does not change project authorization or prevent users from explicitly opening a project link.

## Testing

- npm test -w @owox/idp-owox-better-auth -- --runInBand
- npm run typecheck -w @owox/idp-owox-better-auth
- npm run lint -w @owox/idp-owox-better-auth
- npm run format:check -w @owox/idp-owox-better-auth
- npx markdownlint-cli2 .changeset/6894-user-bound-project-redirect.md