### PR TITLE
fix(bigquery): retry transient query failures instead of failing the run

### DIFF
--- a/.changeset/6887-bigquery-retry-transient-merge-errors.md
+++ b/.changeset/6887-bigquery-retry-transient-merge-errors.md
@@ -4,4 +4,4 @@
 
 # Temporary BigQuery faults no longer fail the whole import
 
-Previously, a single batch rejected by BigQuery with a temporary fault ended the entire run, even after hundreds of thousands of rows had been stored. The storage now waits and saves that batch again, using the existing Max Fetch Retries and Initial Retry Delay settings. Errors that another attempt cannot fix, such as an invalid query or a denied permission, are still reported immediately.
+Previously, a single batch that BigQuery failed with a temporary fault ended the entire run, even after hundreds of thousands of rows had been stored. The storage now waits and saves that batch again, using the existing Max Fetch Retries and Initial Retry Delay settings. This covers both a batch BigQuery rejects outright and one it accepts and then fails while running. Errors that another attempt cannot fix, such as an invalid query or a denied permission, still stop the run immediately.

--- a/.changeset/6887-bigquery-retry-transient-merge-errors.md
+++ b/.changeset/6887-bigquery-retry-transient-merge-errors.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Temporary BigQuery faults no longer fail the whole import
+
+Previously, a single batch rejected by BigQuery with a temporary fault ended the entire run, even after hundreds of thousands of rows had been stored. The storage now waits and saves that batch again, using the existing Max Fetch Retries and Initial Retry Delay settings. Errors that another attempt cannot fix, such as an invalid query or a denied permission, are still reported immediately.

--- a/packages/connectors/src/Core/AbstractSource.js
+++ b/packages/connectors/src/Core/AbstractSource.js
@@ -197,7 +197,7 @@ var AbstractSource = class AbstractSource {
      * @return {number} Delay in milliseconds
      */
     calculateBackoff(attemptNumber) {
-      return this.config.InitialRetryDelay.value * Math.pow(2, attemptNumber - 1) * (0.5 + Math.random());
+      return AsyncUtils.backoffDelay(this.config.InitialRetryDelay.value, attemptNumber);
     }
     //----------------------------------------------------------------
 

--- a/packages/connectors/src/Core/AbstractSource.js
+++ b/packages/connectors/src/Core/AbstractSource.js
@@ -24,14 +24,14 @@ var AbstractSource = class AbstractSource {
           requiredType: "number",
           default: 3,
           label: "Max Fetch Retries",
-          description: "Total attempts for a failed API request, including the first request, before the run stops",
+          description: "Total attempts for a failed request, including the first one, before the run stops. Applies both to reading from the source and to saving into the destination storage",
           attributes: [CONFIG_ATTRIBUTES.ADVANCED]
         },
         InitialRetryDelay: {
           requiredType: "number",
           default: 5000,
           label: "Initial Retry Delay (ms)",
-          description: "Delay before the first retry in milliseconds. Each retry doubles the delay",
+          description: "Delay before the first retry in milliseconds. Each retry doubles the delay. Applies both to reading from the source and to saving into the destination storage",
           attributes: [CONFIG_ATTRIBUTES.ADVANCED]
         }
       });

--- a/packages/connectors/src/Core/Utils/AsyncUtils.js
+++ b/packages/connectors/src/Core/Utils/AsyncUtils.js
@@ -25,4 +25,29 @@ var AsyncUtils = class AsyncUtils {
         return new Promise(resolve => setTimeout(resolve, ms));
     }
 
+    /**
+     * Exponential backoff delay with jitter, in milliseconds.
+     *
+     * The jitter spreads retries that started together — many runs backing off from the
+     * same rate limit — so they do not all come back at the same instant.
+     *
+     * The result is clamped to the longest delay setTimeout can honour. Doubling passes
+     * that ceiling around the twentieth attempt, and beyond it setTimeout falls back to
+     * firing after 1ms — turning a long retry chain into a tight loop against the very
+     * service it is meant to be backing off from. The clamp guards only that overflow: it
+     * sits far above any usable configuration, so a delay a user asked for is never
+     * shortened.
+     *
+     * @param {number} initialDelayMs - Delay before the first retry
+     * @param {number} attemptNumber - Current attempt number (1-based)
+     * @returns {number} The delay to wait before the next attempt
+     */
+    static backoffDelay(initialDelayMs, attemptNumber) {
+        // Largest 32-bit signed integer: setTimeout's documented maximum, about 24.8 days.
+        const maxDelayMs = 2147483647;
+        const delay = initialDelayMs * Math.pow(2, attemptNumber - 1) * (0.5 + Math.random());
+
+        return Math.min(delay, maxDelayMs);
+    }
+
 };

--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -9,6 +9,48 @@ function quoteBigQueryIdentifier(identifier) {
   return `\`${String(identifier).replace(/`/g, '``')}\``;
 }
 
+/**
+ * BigQuery error reasons that Google documents as worth retrying: the query was fine,
+ * the service could not run it right now.
+ *
+ * A reason outside this list is not by itself grounds for a retry, but it does not veto
+ * one either — the status code is still consulted, so a transient fault whose reason we
+ * did not enumerate is not abandoned. In practice the permanent reasons (invalidQuery,
+ * notFound, accessDenied, quotaExceeded) arrive with a 4xx, so they surface immediately.
+ * That includes 'invalidQuery' for an oversized query, which the MERGE loop then handles
+ * by halving the batch.
+ */
+const RETRYABLE_BIGQUERY_REASONS = [
+  'backendError',
+  'internalError',
+  'jobBackendError',
+  'jobInternalError',
+  'rateLimitExceeded',
+];
+
+/**
+ * Transport-level failures with no BigQuery reason attached: the request never reached
+ * the service, or its answer never came back.
+ */
+const RETRYABLE_BIGQUERY_ERROR_CODES = [500, 502, 503, 504, 'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN'];
+
+const DEFAULT_MAX_QUERY_ATTEMPTS = 3;
+const DEFAULT_INITIAL_RETRY_DELAY_MS = 5000;
+
+/**
+ * Reads a retry setting that comes from user configuration. Config validation only checks
+ * `typeof value === 'number'`, and NaN passes that — which would leave the retry loop with
+ * a comparison that is never true. Anything not a real number falls back to the default.
+ *
+ * @param {*} value - The configured value
+ * @param {number} fallback - Used when the value is not a finite number
+ * @param {number} minimum - Lower bound applied to a finite value
+ * @return {number} A usable setting
+ */
+function retrySettingOrDefault(value, fallback, minimum) {
+  return Number.isFinite(value) ? Math.max(minimum, value) : fallback;
+}
+
 function normalizeBigQueryType(type) {
   const normalized = String(type || '').toUpperCase();
   const aliases = {
@@ -928,9 +970,92 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
         useLegacySql: false,
       };
 
-      const [job] = await bigqueryClient.createQueryJob(options);
-      const [rows] = await job.getQueryResults();
-      return rows;
+      // Both are guaranteed finite here, so the exit condition below always becomes true.
+      const maxAttempts = retrySettingOrDefault(
+        this.config.MaxFetchRetries?.value,
+        DEFAULT_MAX_QUERY_ATTEMPTS,
+        1
+      );
+      const initialRetryDelay = retrySettingOrDefault(
+        this.config.InitialRetryDelay?.value,
+        DEFAULT_INITIAL_RETRY_DELAY_MS,
+        0
+      );
+
+      // A retry reuses the job it already submitted rather than sending a new one: the
+      // statement has already been handed to BigQuery, so resubmitting would run it a
+      // second time — paying for the scan twice and letting two mutations of the same
+      // rows overlap. Only a failure that happened before a job existed submits one.
+      //
+      // A job that fails on BigQuery's side is reported by createQueryJob, which inspects
+      // the job's status, so those attempts leave `job` unset and do resubmit. What gets
+      // polled again is the case this guards: the job was accepted and only the wait for
+      // its results failed.
+      let job = null;
+
+      for (let attempt = 1; ; attempt++) {
+        try {
+          if (!job) {
+            const [createdJob] = await bigqueryClient.createQueryJob(options);
+            job = createdJob;
+          }
+
+          const [rows] = await job.getQueryResults();
+          return rows;
+        } catch (error) {
+          if (attempt >= maxAttempts || !this._isRetryableBigQueryError(error)) {
+            throw error;
+          }
+
+          const delay = AsyncUtils.backoffDelay(initialRetryDelay, attempt);
+          const reason = this._bigQueryErrorReasons(error)[0] || error.code || 'unknown error';
+
+          this.config.logMessage(
+            `BigQuery query failed (${reason}), retrying in ${Math.round(delay / 1000)}s (attempt ${attempt + 1} of ${maxAttempts})`
+          );
+
+          await AsyncUtils.delay(delay);
+        }
+      }
+    }
+
+  //---- _bigQueryErrorReasons ---------------------------------------
+    /**
+     * Reason codes BigQuery attached to a failure, e.g. ['backendError'].
+     * Empty for transport-level errors, which carry no reason.
+     *
+     * @param {Error} error - The error thrown by the BigQuery client
+     * @return {Array<string>} The reason codes, in the order BigQuery reported them
+     */
+    _bigQueryErrorReasons(error) {
+      if (!error || !Array.isArray(error.errors)) {
+        return [];
+      }
+
+      return error.errors.map(item => item && item.reason).filter(Boolean);
+    }
+
+  //---- _isRetryableBigQueryError -----------------------------------
+    /**
+     * Whether a failed query is worth running again. A failure matching neither a known
+     * reason nor a transient status code is treated as permanent, so a new failure mode
+     * surfaces to the user instead of silently consuming the configured attempts.
+     *
+     * @param {Error} error - The error thrown by the BigQuery client
+     * @return {boolean} True when the same query may succeed on another attempt
+     */
+    _isRetryableBigQueryError(error) {
+      if (!error) {
+        return false;
+      }
+
+      const reasons = this._bigQueryErrorReasons(error);
+
+      if (reasons.some(reason => RETRYABLE_BIGQUERY_REASONS.includes(reason))) {
+        return true;
+      }
+
+      return RETRYABLE_BIGQUERY_ERROR_CODES.includes(error.code);
     }
 
   //---- obfuscateSpecialCharacters ----------------------------------

--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -10,15 +10,18 @@ function quoteBigQueryIdentifier(identifier) {
 }
 
 /**
- * BigQuery error reasons that Google documents as worth retrying: the query was fine,
+ * BigQuery error reasons that Google documents as worth retrying: the statement was fine,
  * the service could not run it right now.
  *
- * A reason outside this list is not by itself grounds for a retry, but it does not veto
- * one either — the status code is still consulted, so a transient fault whose reason we
- * did not enumerate is not abandoned. In practice the permanent reasons (invalidQuery,
- * notFound, accessDenied, quotaExceeded) arrive with a 4xx, so they surface immediately.
- * That includes 'invalidQuery' for an oversized query, which the MERGE loop then handles
- * by halving the batch.
+ * These are the reasons the client library never retries on its own. Its `shouldRetryRequest`
+ * acts on the HTTP status of a single request, so it cannot see a job that was accepted and
+ * then failed while running — which is the case this list exists for.
+ *
+ * A reason outside this list is not by itself grounds for a retry, but it does not veto one
+ * either: a reason-less transport failure is still classified by its code. The permanent
+ * reasons (invalidQuery, notFound, accessDenied, quotaExceeded) arrive with a 4xx, so they
+ * surface immediately. That includes 'invalidQuery' for an oversized query, which the MERGE
+ * loop then handles by halving the batch.
  */
 const RETRYABLE_BIGQUERY_REASONS = [
   'backendError',
@@ -26,16 +29,28 @@ const RETRYABLE_BIGQUERY_REASONS = [
   'jobBackendError',
   'jobInternalError',
   'rateLimitExceeded',
+  'jobRateLimitExceeded',
 ];
 
 /**
- * Transport-level failures with no BigQuery reason attached: the request never reached
- * the service, or its answer never came back.
+ * Transport-level failures with no BigQuery reason attached: the answer to a request never
+ * came back, so whatever it was asking about may still be fine.
+ *
+ * HTTP statuses are deliberately absent. @google-cloud/common already retries 408/429/5xx
+ * through `shouldRetryRequest`, so listing them here would only stack a second ladder on
+ * top of the client's own and report the total as one attempt.
  */
-const RETRYABLE_BIGQUERY_ERROR_CODES = [500, 502, 503, 504, 'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN'];
+const RETRYABLE_BIGQUERY_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN'];
 
 const DEFAULT_MAX_QUERY_ATTEMPTS = 3;
 const DEFAULT_INITIAL_RETRY_DELAY_MS = 5000;
+
+/**
+ * Ceiling for a single backoff wait. `MaxFetchRetries` has no maximum, and a run holds one
+ * of the project's concurrent slots while it sleeps, so uncapped doubling lets one BigQuery
+ * outage park a run for over an hour before it reports the failure.
+ */
+const MAX_RETRY_DELAY_MS = 60000;
 
 /**
  * Reads a retry setting that comes from user configuration. Config validation only checks
@@ -982,15 +997,19 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
         0
       );
 
-      // A retry reuses the job it already submitted rather than sending a new one: the
-      // statement has already been handed to BigQuery, so resubmitting would run it a
-      // second time — paying for the scan twice and letting two mutations of the same
-      // rows overlap. Only a failure that happened before a job existed submits one.
+      // Whether a retry resubmits the statement or polls the job again turns on what
+      // failed, because createQueryJob does not wait for the job to finish. It only
+      // inspects `status.errors` on the insert response, and a MERGE that BigQuery
+      // accepts comes back RUNNING — so a job that fails during execution resolves
+      // createQueryJob successfully and reports the failure through getQueryResults.
       //
-      // A job that fails on BigQuery's side is reported by createQueryJob, which inspects
-      // the job's status, so those attempts leave `job` unset and do resubmit. What gets
-      // polled again is the case this guards: the job was accepted and only the wait for
-      // its results failed.
+      //   - The error carries a BigQuery reason: the job reached a terminal state.
+      //     Polling it again returns the same error forever, so the statement has to be
+      //     sent again. That is safe — a failed DML job commits nothing, so there is no
+      //     half-applied MERGE to overlap with.
+      //   - The error carries no reason: a transport fault, and the job it was asking
+      //     about may still be running. Poll that job again rather than paying for a
+      //     second scan and letting two mutations of the same rows overlap.
       let job = null;
 
       for (let attempt = 1; ; attempt++) {
@@ -1007,8 +1026,18 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
             throw error;
           }
 
-          const delay = AsyncUtils.backoffDelay(initialRetryDelay, attempt);
-          const reason = this._bigQueryErrorReasons(error)[0] || error.code || 'unknown error';
+          const reasons = this._bigQueryErrorReasons(error);
+
+          // BigQuery answered, so the job is finished and failed. Drop it and resubmit.
+          if (reasons.length > 0) {
+            job = null;
+          }
+
+          const delay = Math.min(
+            AsyncUtils.backoffDelay(initialRetryDelay, attempt),
+            MAX_RETRY_DELAY_MS
+          );
+          const reason = reasons[0] || error.code || 'unknown error';
 
           this.config.logMessage(
             `BigQuery query failed (${reason}), retrying in ${Math.round(delay / 1000)}s (attempt ${attempt + 1} of ${maxAttempts})`
@@ -1038,7 +1067,7 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
   //---- _isRetryableBigQueryError -----------------------------------
     /**
      * Whether a failed query is worth running again. A failure matching neither a known
-     * reason nor a transient status code is treated as permanent, so a new failure mode
+     * reason nor a network-level code is treated as permanent, so a new failure mode
      * surfaces to the user instead of silently consuming the configured attempts.
      *
      * @param {Error} error - The error thrown by the BigQuery client

--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -1003,13 +1003,10 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       // accepts comes back RUNNING — so a job that fails during execution resolves
       // createQueryJob successfully and reports the failure through getQueryResults.
       //
-      //   - The error carries a BigQuery reason: the job reached a terminal state.
-      //     Polling it again returns the same error forever, so the statement has to be
-      //     sent again. That is safe — a failed DML job commits nothing, so there is no
-      //     half-applied MERGE to overlap with.
-      //   - The error carries no reason: a transport fault, and the job it was asking
-      //     about may still be running. Poll that job again rather than paying for a
-      //     second scan and letting two mutations of the same rows overlap.
+      // Once a job exists, only the job itself can say which happened: a failed job and
+      // a failed poll of a healthy job both arrive as a reasoned error. Getting it wrong
+      // either abandons a live job or runs a second copy of the statement beside it, so
+      // the job is asked rather than inferred.
       let job = null;
 
       for (let attempt = 1; ; attempt++) {
@@ -1028,8 +1025,8 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
 
           const reasons = this._bigQueryErrorReasons(error);
 
-          // BigQuery answered, so the job is finished and failed. Drop it and resubmit.
-          if (reasons.length > 0) {
+          // Nothing left to poll: the statement has to be sent again.
+          if (job && (await this._hasJobFinishedWithError(job))) {
             job = null;
           }
 
@@ -1062,6 +1059,33 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       }
 
       return error.errors.map(item => item && item.reason).filter(Boolean);
+    }
+
+  //---- _hasJobFinishedWithError ------------------------------------
+    /**
+     * Whether BigQuery considers this job finished and failed, so that polling it again
+     * can only return the same error.
+     *
+     * The error alone does not answer this. A transient 5xx on `GET /queries/{id}` carries
+     * `backendError` in its body, and a per-user `rateLimitExceeded` on the poll describes
+     * the request, not the job — both while the statement keeps running. This is the same
+     * check the client library's own `poll_` makes.
+     *
+     * A job whose status cannot be read counts as not failed: polling a finished job again
+     * wastes an attempt, while resubmitting beside a running one pays for a second scan and
+     * lets two mutations of the same rows overlap.
+     *
+     * @param {object} job - The job returned by createQueryJob
+     * @return {Promise<boolean>} True when the job is DONE and carries an errorResult
+     */
+    async _hasJobFinishedWithError(job) {
+      try {
+        const [metadata] = await job.getMetadata();
+
+        return metadata?.status?.state === 'DONE' && Boolean(metadata.status.errorResult);
+      } catch {
+        return false;
+      }
     }
 
   //---- _isRetryableBigQueryError -----------------------------------

--- a/packages/connectors/src/Storages/GoogleBigQuery/README.md
+++ b/packages/connectors/src/Storages/GoogleBigQuery/README.md
@@ -4,6 +4,14 @@
 
 Storage for Google BigQuery
 
+## Retries
+
+BigQuery sometimes rejects a query with a temporary fault, such as `backendError` or
+`rateLimitExceeded`. The storage waits and runs that query again instead of failing the
+run, reusing the connector's **Max Fetch Retries** and **Initial Retry Delay** settings.
+Faults that another attempt cannot fix, such as an invalid query or a denied permission,
+are reported straight away.
+
 ## Environments
 
 This storage works in the following environments:

--- a/packages/connectors/src/Storages/GoogleBigQuery/README.md
+++ b/packages/connectors/src/Storages/GoogleBigQuery/README.md
@@ -6,11 +6,13 @@ Storage for Google BigQuery
 
 ## Retries
 
-BigQuery sometimes rejects a query with a temporary fault, such as `backendError` or
-`rateLimitExceeded`. The storage waits and runs that query again instead of failing the
-run, reusing the connector's **Max Fetch Retries** and **Initial Retry Delay** settings.
-Faults that another attempt cannot fix, such as an invalid query or a denied permission,
-are reported straight away.
+BigQuery sometimes fails a query with a temporary fault, such as `backendError`.
+The storage waits and runs that query again instead of failing the run.
+It reuses the connector's **Max Fetch Retries** and **Initial Retry Delay** settings.
+Each wait doubles the previous one, up to one minute.
+
+Some faults no further attempt can fix, such as an invalid query or a denied
+permission. The storage reports those straight away.
 
 ## Environments
 

--- a/packages/connectors/test/Core/AsyncUtils.test.js
+++ b/packages/connectors/test/Core/AsyncUtils.test.js
@@ -1,0 +1,72 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadGasClass } from '../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+loadGasClass(path.join(__dirname, '../../src/Core/Utils/AsyncUtils.js'));
+
+// setTimeout coerces any delay past this to 1ms, so a backoff above it would run
+// immediately instead of waiting — the failure mode the cap exists to prevent.
+const SET_TIMEOUT_CEILING_MS = 2 ** 31 - 1;
+
+describe('backoffDelay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('doubles with each attempt', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    expect(globalThis.AsyncUtils.backoffDelay(1000, 1)).toBe(1000);
+    expect(globalThis.AsyncUtils.backoffDelay(1000, 2)).toBe(2000);
+    expect(globalThis.AsyncUtils.backoffDelay(1000, 3)).toBe(4000);
+  });
+
+  it('spreads simultaneous retries instead of returning one fixed delay', () => {
+    // Without jitter every run backing off from the same rate limit returns at the
+    // same instant and hits it again together.
+    const delays = new Set(
+      Array.from({ length: 50 }, () => globalThis.AsyncUtils.backoffDelay(1000, 1))
+    );
+
+    expect(delays.size).toBeGreaterThan(1);
+  });
+
+  it('never exceeds what setTimeout can honour, however many attempts have passed', () => {
+    for (const attempt of [20, 25, 40, 100]) {
+      const delay = globalThis.AsyncUtils.backoffDelay(5000, attempt);
+
+      expect(delay).toBeLessThanOrEqual(SET_TIMEOUT_CEILING_MS);
+    }
+  });
+
+  it('stays a real number where doubling alone would overflow to Infinity', () => {
+    // 2^1024 is Infinity; setTimeout(Infinity) fires immediately, turning the backoff
+    // into a tight loop against the service being retried.
+    const delay = globalThis.AsyncUtils.backoffDelay(5000, 2000);
+
+    expect(Number.isFinite(delay)).toBe(true);
+    expect(delay).toBe(SET_TIMEOUT_CEILING_MS);
+  });
+
+  it('never returns less than a long delay the user configured', () => {
+    // A connector facing a strict rate limit may be configured to wait minutes. Clamping
+    // that down would retry too early and make the rate limiting worse.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    expect(globalThis.AsyncUtils.backoffDelay(300000, 1)).toBe(300000);
+    expect(globalThis.AsyncUtils.backoffDelay(300000, 2)).toBe(600000);
+  });
+
+  it('leaves the default retry configuration untouched', () => {
+    // MaxFetchRetries defaults to 3 with a 5s initial delay, so the cap must not
+    // change what those runs already do.
+    vi.spyOn(Math, 'random').mockReturnValue(1);
+
+    expect(globalThis.AsyncUtils.backoffDelay(5000, 1)).toBe(7500);
+    expect(globalThis.AsyncUtils.backoffDelay(5000, 2)).toBe(15000);
+    expect(globalThis.AsyncUtils.backoffDelay(5000, 3)).toBe(30000);
+  });
+});

--- a/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
+++ b/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
@@ -1,12 +1,13 @@
 import path from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { loadGasClass } from '../../support/loadGasClass.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const abstractStoragePath = path.join(__dirname, '../../../src/Core/AbstractStorage.js');
 const dateUtilsPath = path.join(__dirname, '../../../src/Core/Utils/DateUtils.js');
+const asyncUtilsPath = path.join(__dirname, '../../../src/Core/Utils/AsyncUtils.js');
 const storagePath = path.join(
   __dirname,
   '../../../src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js'
@@ -20,6 +21,7 @@ globalThis.require = createRequire(import.meta.url);
 
 loadGasClass(abstractStoragePath);
 loadGasClass(dateUtilsPath);
+loadGasClass(asyncUtilsPath);
 loadGasClass(storagePath);
 const proto = globalThis.GoogleBigQueryStorage.prototype;
 
@@ -488,5 +490,342 @@ describe('formatColumnValue date handling', () => {
     const value = proto.formatColumnValue.call(bare(), '2026-08-30T10:00:00', 'DATETIME');
 
     expect(value).toBe('2026-08-30 10:00:00');
+  });
+});
+
+describe('executeQuery transient-error retries', () => {
+  // Shape of a failure from @google-cloud/common's ApiError: `code` is the HTTP status
+  // and `errors[].reason` is BigQuery's own classification of what went wrong.
+  const apiError = (reason, code = 500) =>
+    Object.assign(
+      new Error('Error encountered during execution. Retrying may solve the problem.'),
+      {
+        code,
+        errors: reason ? [{ reason, message: 'Error encountered during execution.' }] : undefined,
+      }
+    );
+
+  const retryingStorage = ({ failures, error = apiError('backendError'), retries = 3 } = {}) => {
+    const waited = [];
+    const messages = [];
+    let attempts = 0;
+
+    // Built on the prototype so executeQuery can reach its own helpers.
+    const storage = Object.assign(Object.create(proto), {
+      config: {
+        MaxFetchRetries: configValue(retries),
+        InitialRetryDelay: configValue(1000),
+        logMessage: message => messages.push(message),
+      },
+      getBigQueryClient: () => ({
+        createQueryJob: async () => {
+          attempts += 1;
+          if (attempts <= failures) {
+            throw error;
+          }
+          return [{ getQueryResults: async () => [[{ ok: true }]] }];
+        },
+      }),
+    });
+
+    return { storage, waited, messages, attemptCount: () => attempts };
+  };
+
+  let originalDelay;
+
+  beforeEach(() => {
+    originalDelay = globalThis.AsyncUtils.delay;
+  });
+
+  afterEach(() => {
+    globalThis.AsyncUtils.delay = originalDelay;
+  });
+
+  const withRecordedDelays = waited => {
+    globalThis.AsyncUtils.delay = async ms => {
+      waited.push(ms);
+    };
+  };
+
+  it('retries a backendError and returns the rows the retry produced', async () => {
+    // The production failure: one MERGE batch out of a thousand hit a temporary
+    // BigQuery fault and took the whole run down with it.
+    const { storage, waited, attemptCount } = retryingStorage({ failures: 1 });
+    withRecordedDelays(waited);
+
+    const rows = await proto.executeQuery.call(storage, 'MERGE INTO t ...');
+
+    expect(rows).toEqual([{ ok: true }]);
+    expect(attemptCount()).toBe(2);
+    expect(waited).toHaveLength(1);
+  });
+
+  it('says in the run log that it is retrying, and why', async () => {
+    const { storage, waited, messages } = retryingStorage({ failures: 1 });
+    withRecordedDelays(waited);
+
+    await proto.executeQuery.call(storage, 'MERGE INTO t ...');
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('backendError');
+    expect(messages[0]).toContain('attempt 2 of 3');
+  });
+
+  it('gives up after the configured attempts and rethrows the original error', async () => {
+    // The caller must see BigQuery's own error, not a wrapper that hides the reason.
+    const error = apiError('backendError');
+    const { storage, waited, attemptCount } = retryingStorage({ failures: Infinity, error });
+    withRecordedDelays(waited);
+
+    await expect(proto.executeQuery.call(storage, 'MERGE INTO t ...')).rejects.toBe(error);
+    expect(attemptCount()).toBe(3);
+  });
+
+  it('doubles the backoff on each attempt', async () => {
+    // Math.random is pinned: the jitter ranges of consecutive attempts overlap, so
+    // comparing two live delays fails roughly 6% of the time.
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const { storage, waited } = retryingStorage({ failures: 2 });
+    withRecordedDelays(waited);
+
+    await proto.executeQuery.call(storage, 'MERGE INTO t ...');
+
+    // InitialRetryDelay 1000 x 2^(attempt-1) x (0.5 + 0.5)
+    expect(waited).toEqual([1000, 2000]);
+    randomSpy.mockRestore();
+  });
+
+  it('falls back to built-in retry settings when the config carries none', async () => {
+    // The storage config normally inherits these from the source config; a storage built
+    // without them must still retry rather than read undefined attempt counts.
+    const { storage, waited, attemptCount } = retryingStorage({ failures: Infinity });
+    delete storage.config.MaxFetchRetries;
+    delete storage.config.InitialRetryDelay;
+    withRecordedDelays(waited);
+
+    await expect(proto.executeQuery.call(storage, 'SELECT 1')).rejects.toThrow();
+
+    expect(attemptCount()).toBe(3);
+    expect(waited.every(ms => Number.isFinite(ms) && ms > 0)).toBe(true);
+  });
+
+  it('ignores a NaN retry count instead of retrying forever', async () => {
+    // Config validation accepts NaN, since typeof NaN === 'number'. Left unchecked it
+    // makes the loop's exit comparison permanently false.
+    const { storage, waited, attemptCount } = retryingStorage({
+      failures: Infinity,
+      retries: Number.NaN,
+    });
+    withRecordedDelays(waited);
+
+    await expect(proto.executeQuery.call(storage, 'SELECT 1')).rejects.toThrow();
+
+    expect(attemptCount()).toBe(3);
+  });
+
+  it('treats a retry count below one as a single attempt', async () => {
+    const { storage, waited, attemptCount } = retryingStorage({ failures: Infinity, retries: 0 });
+    withRecordedDelays(waited);
+
+    await expect(proto.executeQuery.call(storage, 'SELECT 1')).rejects.toThrow();
+
+    expect(attemptCount()).toBe(1);
+    expect(waited).toEqual([]);
+  });
+
+  it('does not retry an oversized query, so the MERGE loop can halve the batch', async () => {
+    // executeMergeQueryRecursively catches this and retries with a smaller batch;
+    // retrying the same oversized query here would waste attempts and delay that.
+    const error = apiError('invalidQuery', 400);
+    error.message = 'The query is too large';
+    const { storage, waited, attemptCount } = retryingStorage({ failures: Infinity, error });
+    withRecordedDelays(waited);
+
+    await expect(proto.executeQuery.call(storage, 'MERGE INTO t ...')).rejects.toBe(error);
+    expect(attemptCount()).toBe(1);
+    expect(waited).toEqual([]);
+  });
+
+  it('does not retry a permission failure', async () => {
+    const { storage, waited, attemptCount } = retryingStorage({
+      failures: Infinity,
+      error: apiError('accessDenied', 403),
+    });
+    withRecordedDelays(waited);
+
+    await expect(proto.executeQuery.call(storage, 'SELECT 1')).rejects.toThrow();
+    expect(attemptCount()).toBe(1);
+  });
+
+  it('does not retry an exhausted quota, which no amount of waiting fixes', async () => {
+    const { storage, waited, attemptCount } = retryingStorage({
+      failures: Infinity,
+      error: apiError('quotaExceeded', 403),
+    });
+    withRecordedDelays(waited);
+
+    await expect(proto.executeQuery.call(storage, 'SELECT 1')).rejects.toThrow();
+    expect(attemptCount()).toBe(1);
+  });
+
+  it('retries a rate limit, which clears on its own', async () => {
+    const { storage, waited, attemptCount } = retryingStorage({
+      failures: 1,
+      error: apiError('rateLimitExceeded', 403),
+    });
+    withRecordedDelays(waited);
+
+    await proto.executeQuery.call(storage, 'SELECT 1');
+
+    expect(attemptCount()).toBe(2);
+  });
+
+  it('retries a dropped connection, which carries no BigQuery reason', async () => {
+    const { storage, waited, attemptCount } = retryingStorage({
+      failures: 1,
+      error: Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+    });
+    withRecordedDelays(waited);
+
+    await proto.executeQuery.call(storage, 'SELECT 1');
+
+    expect(attemptCount()).toBe(2);
+  });
+
+  it('polls the job it already submitted instead of running the statement twice', async () => {
+    // The statement is already with BigQuery once createQueryJob resolves. Resubmitting
+    // would run the MERGE a second time: the scan is paid for twice, and two mutations of
+    // the same rows can overlap.
+    let jobsCreated = 0;
+    let resultAttempts = 0;
+    const storage = Object.assign(Object.create(proto), {
+      config: {
+        MaxFetchRetries: configValue(3),
+        InitialRetryDelay: configValue(1000),
+        logMessage() {},
+      },
+      getBigQueryClient: () => ({
+        createQueryJob: async () => {
+          jobsCreated += 1;
+          return [
+            {
+              getQueryResults: async () => {
+                resultAttempts += 1;
+                if (resultAttempts === 1) {
+                  throw Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+                }
+                return [[{ ok: true }]];
+              },
+            },
+          ];
+        },
+      }),
+    });
+    const originalDelay = globalThis.AsyncUtils.delay;
+    globalThis.AsyncUtils.delay = async () => {};
+
+    try {
+      const rows = await proto.executeQuery.call(storage, 'MERGE INTO t ...');
+
+      expect(rows).toEqual([{ ok: true }]);
+      expect(resultAttempts).toBe(2);
+      expect(jobsCreated).toBe(1);
+    } finally {
+      globalThis.AsyncUtils.delay = originalDelay;
+    }
+  });
+
+  it('submits a new job when the failure happened before one existed', async () => {
+    // createQueryJob reports a job BigQuery itself rejected, so there is nothing to poll
+    // and the statement has to be sent again.
+    const { storage, waited, attemptCount } = retryingStorage({ failures: 1 });
+    withRecordedDelays(waited);
+
+    await proto.executeQuery.call(storage, 'MERGE INTO t ...');
+
+    expect(attemptCount()).toBe(2);
+  });
+
+  it('makes a single attempt when retries are configured off', async () => {
+    const { storage, waited, attemptCount } = retryingStorage({ failures: Infinity, retries: 1 });
+    withRecordedDelays(waited);
+
+    await expect(proto.executeQuery.call(storage, 'SELECT 1')).rejects.toThrow();
+    expect(attemptCount()).toBe(1);
+    expect(waited).toEqual([]);
+  });
+});
+
+describe('MERGE batch chain with a transient failure', () => {
+  let originalDelay;
+
+  beforeEach(() => {
+    originalDelay = globalThis.AsyncUtils.delay;
+    globalThis.AsyncUtils.delay = async () => {};
+  });
+
+  afterEach(() => {
+    globalThis.AsyncUtils.delay = originalDelay;
+  });
+
+  it('completes every batch when one of them fails transiently', async () => {
+    // End to end over the path that failed in production: batch 2 of 3 hits a
+    // backendError, and the run must still store all three batches. Driven through
+    // executeMergeQueryRecursively with an explicit batch size of 1, since the buffer
+    // is otherwise sent as a single query and only split when it exceeds 1MB.
+    let jobs = 0;
+    const storage = Object.assign(Object.create(proto), {
+      totalRecordsProcessed: 0,
+      config: {
+        MaxFetchRetries: configValue(3),
+        InitialRetryDelay: configValue(1000),
+        logMessage() {},
+      },
+      buildMergeQuery: keys => `MERGE ${keys.join(',')}`,
+      getBigQueryClient: () => ({
+        createQueryJob: async () => {
+          jobs += 1;
+          if (jobs === 2) {
+            throw Object.assign(new Error('Error encountered during execution.'), {
+              code: 500,
+              errors: [{ reason: 'backendError' }],
+            });
+          }
+          return [{ getQueryResults: async () => [[]] }];
+        },
+      }),
+    });
+
+    await proto.executeMergeQueryRecursively.call(storage, ['a', 'b', 'c'], 1);
+
+    // 3 batches + 1 retry of the failed one
+    expect(jobs).toBe(4);
+    expect(storage.totalRecordsProcessed).toBe(3);
+  });
+
+  it('leaves the buffer intact when the failure is permanent', async () => {
+    // Nothing recovers the buffer on a failed run, so it must not be cleared as if
+    // the records had been stored.
+    const storage = Object.assign(Object.create(proto), {
+      totalRecordsProcessed: 0,
+      updatedRecordsBuffer: { a: {}, b: {} },
+      config: {
+        MaxFetchRetries: configValue(3),
+        InitialRetryDelay: configValue(1000),
+        logMessage() {},
+      },
+      buildMergeQuery: keys => `MERGE ${keys.join(',')}`,
+      getBigQueryClient: () => ({
+        createQueryJob: async () => {
+          throw Object.assign(new Error('Access Denied'), {
+            code: 403,
+            errors: [{ reason: 'accessDenied' }],
+          });
+        },
+      }),
+    });
+
+    await expect(proto.executeQueryWithSizeLimit.call(storage)).rejects.toThrow('Access Denied');
+    expect(storage.updatedRecordsBuffer).toEqual({ a: {}, b: {} });
   });
 });

--- a/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
+++ b/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
@@ -692,10 +692,121 @@ describe('executeQuery transient-error retries', () => {
     expect(attemptCount()).toBe(2);
   });
 
-  it('polls the job it already submitted instead of running the statement twice', async () => {
-    // The statement is already with BigQuery once createQueryJob resolves. Resubmitting
+  it('resubmits the statement when the job failed after BigQuery accepted it', async () => {
+    // createQueryJob does not wait for the job: a MERGE that BigQuery accepts and then
+    // fails while running resolves the insert and reports the failure from
+    // getQueryResults. That job is DONE with an errorResult, so polling it again returns
+    // the same error forever — the statement has to be sent again.
+    let jobsCreated = 0;
+    let resultAttempts = 0;
+    const storage = Object.assign(Object.create(proto), {
+      config: {
+        MaxFetchRetries: configValue(3),
+        InitialRetryDelay: configValue(1000),
+        logMessage() {},
+      },
+      getBigQueryClient: () => ({
+        createQueryJob: async () => {
+          jobsCreated += 1;
+          return [
+            {
+              getQueryResults: async () => {
+                resultAttempts += 1;
+                if (resultAttempts === 1) {
+                  throw apiError('backendError');
+                }
+                return [[{ ok: true }]];
+              },
+            },
+          ];
+        },
+      }),
+    });
+    const originalDelay = globalThis.AsyncUtils.delay;
+    globalThis.AsyncUtils.delay = async () => {};
+
+    try {
+      const rows = await proto.executeQuery.call(storage, 'MERGE INTO t ...');
+
+      expect(rows).toEqual([{ ok: true }]);
+      expect(jobsCreated).toBe(2);
+      expect(resultAttempts).toBe(2);
+    } finally {
+      globalThis.AsyncUtils.delay = originalDelay;
+    }
+  });
+
+  it('gives up on a job that keeps failing during execution, without polling it twice', async () => {
+    // Every attempt must be a fresh statement; re-polling the same dead job would burn
+    // the attempts on an answer that cannot change.
+    let jobsCreated = 0;
+    const pollsPerJob = [];
+    const storage = Object.assign(Object.create(proto), {
+      config: {
+        MaxFetchRetries: configValue(3),
+        InitialRetryDelay: configValue(1000),
+        logMessage() {},
+      },
+      getBigQueryClient: () => ({
+        createQueryJob: async () => {
+          jobsCreated += 1;
+          const index = pollsPerJob.push(0) - 1;
+          return [
+            {
+              getQueryResults: async () => {
+                pollsPerJob[index] += 1;
+                throw apiError('internalError');
+              },
+            },
+          ];
+        },
+      }),
+    });
+    const originalDelay = globalThis.AsyncUtils.delay;
+    globalThis.AsyncUtils.delay = async () => {};
+
+    try {
+      await expect(proto.executeQuery.call(storage, 'MERGE INTO t ...')).rejects.toThrow();
+
+      expect(jobsCreated).toBe(3);
+      expect(pollsPerJob).toEqual([1, 1, 1]);
+    } finally {
+      globalThis.AsyncUtils.delay = originalDelay;
+    }
+  });
+
+  it('retries a job-level rate limit, which the client library never retries itself', async () => {
+    // jobRateLimitExceeded arrives with a 400, so shouldRetryRequest ignores it, but
+    // Google documents it as a retry-with-backoff condition.
+    const { storage, waited, attemptCount } = retryingStorage({
+      failures: 1,
+      error: apiError('jobRateLimitExceeded', 400),
+    });
+    withRecordedDelays(waited);
+
+    await proto.executeQuery.call(storage, 'MERGE INTO t ...');
+
+    expect(attemptCount()).toBe(2);
+  });
+
+  it('caps a single backoff wait so an outage cannot park the run for an hour', async () => {
+    // MaxFetchRetries has no maximum and the run holds a concurrency slot while it
+    // sleeps, so the doubling needs a ceiling.
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const { storage, waited } = retryingStorage({ failures: Infinity, retries: 8 });
+    withRecordedDelays(waited);
+
+    await expect(proto.executeQuery.call(storage, 'MERGE INTO t ...')).rejects.toThrow();
+
+    expect(Math.max(...waited)).toBe(60000);
+    expect(waited).toEqual([1000, 2000, 4000, 8000, 16000, 32000, 60000]);
+    randomSpy.mockRestore();
+  });
+
+  it('polls the job it already submitted when the failure carries no BigQuery reason', async () => {
+    // A dropped socket says nothing about the job, which may still be running. Resubmitting
     // would run the MERGE a second time: the scan is paid for twice, and two mutations of
-    // the same rows can overlap.
+    // the same rows can overlap. Contrast the reasoned failures above, which must resubmit.
     let jobsCreated = 0;
     let resultAttempts = 0;
     const storage = Object.assign(Object.create(proto), {

--- a/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
+++ b/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
@@ -505,6 +505,13 @@ describe('executeQuery transient-error retries', () => {
       }
     );
 
+  // What job.getMetadata() returns for a job BigQuery has finished and failed, versus one
+  // it is still running. The retry loop asks the job which of the two it is.
+  const failedJobMetadata = {
+    status: { state: 'DONE', errorResult: { reason: 'backendError' } },
+  };
+  const runningJobMetadata = { status: { state: 'RUNNING' } };
+
   const retryingStorage = ({ failures, error = apiError('backendError'), retries = 3 } = {}) => {
     const waited = [];
     const messages = [];
@@ -710,6 +717,7 @@ describe('executeQuery transient-error retries', () => {
           jobsCreated += 1;
           return [
             {
+              getMetadata: async () => [failedJobMetadata],
               getQueryResults: async () => {
                 resultAttempts += 1;
                 if (resultAttempts === 1) {
@@ -753,6 +761,7 @@ describe('executeQuery transient-error retries', () => {
           const index = pollsPerJob.push(0) - 1;
           return [
             {
+              getMetadata: async () => [failedJobMetadata],
               getQueryResults: async () => {
                 pollsPerJob[index] += 1;
                 throw apiError('internalError');
@@ -803,6 +812,89 @@ describe('executeQuery transient-error retries', () => {
     randomSpy.mockRestore();
   });
 
+  it('keeps polling when the poll failed but the job behind it is still running', async () => {
+    // A transient 5xx on GET /queries/{id} carries backendError in its body, and a
+    // per-user rate limit on the poll describes the request rather than the job. Neither
+    // says the statement stopped, so resubmitting would run a second MERGE beside a live
+    // one — the error is not evidence, the job's own status is.
+    let jobsCreated = 0;
+    let resultAttempts = 0;
+    const storage = Object.assign(Object.create(proto), {
+      config: {
+        MaxFetchRetries: configValue(3),
+        InitialRetryDelay: configValue(1000),
+        logMessage() {},
+      },
+      getBigQueryClient: () => ({
+        createQueryJob: async () => {
+          jobsCreated += 1;
+          return [
+            {
+              getMetadata: async () => [runningJobMetadata],
+              getQueryResults: async () => {
+                resultAttempts += 1;
+                if (resultAttempts === 1) {
+                  throw apiError('backendError');
+                }
+                return [[{ ok: true }]];
+              },
+            },
+          ];
+        },
+      }),
+    });
+    const originalDelay = globalThis.AsyncUtils.delay;
+    globalThis.AsyncUtils.delay = async () => {};
+
+    try {
+      const rows = await proto.executeQuery.call(storage, 'MERGE INTO t ...');
+
+      expect(rows).toEqual([{ ok: true }]);
+      expect(jobsCreated).toBe(1);
+      expect(resultAttempts).toBe(2);
+    } finally {
+      globalThis.AsyncUtils.delay = originalDelay;
+    }
+  });
+
+  it('keeps the job when its status cannot be read, rather than running the statement twice', async () => {
+    // An unreadable status is not proof the job died. Polling a finished job again costs
+    // one attempt; resubmitting beside a running one costs a duplicate MERGE.
+    let jobsCreated = 0;
+    const storage = Object.assign(Object.create(proto), {
+      config: {
+        MaxFetchRetries: configValue(3),
+        InitialRetryDelay: configValue(1000),
+        logMessage() {},
+      },
+      getBigQueryClient: () => ({
+        createQueryJob: async () => {
+          jobsCreated += 1;
+          return [
+            {
+              getMetadata: async () => {
+                throw new Error('metadata unavailable');
+              },
+              getQueryResults: async () => {
+                throw apiError('backendError');
+              },
+            },
+          ];
+        },
+      }),
+    });
+    const originalDelay = globalThis.AsyncUtils.delay;
+    globalThis.AsyncUtils.delay = async () => {};
+
+    try {
+      await expect(proto.executeQuery.call(storage, 'MERGE INTO t ...')).rejects.toThrow();
+
+      expect(jobsCreated).toBe(1);
+    } finally {
+      globalThis.AsyncUtils.delay = originalDelay;
+    }
+  });
+
   it('polls the job it already submitted when the failure carries no BigQuery reason', async () => {
     // A dropped socket says nothing about the job, which may still be running. Resubmitting
     // would run the MERGE a second time: the scan is paid for twice, and two mutations of
@@ -820,6 +912,7 @@ describe('executeQuery transient-error retries', () => {
           jobsCreated += 1;
           return [
             {
+              getMetadata: async () => [runningJobMetadata],
               getQueryResults: async () => {
                 resultAttempts += 1;
                 if (resultAttempts === 1) {


### PR DESCRIPTION
# Problem

BigQuery occasionally rejects a query with a temporary fault — `backendError`, "Error encountered during execution. Retrying may solve the problem." — where the query itself is fine and the service simply could not run it at that moment. The storage sent every MERGE batch through `executeQuery`, which had no error handling at all, so one rejected batch propagated straight up and ended the whole import. A production run hit this after storing roughly 260,000 rows across about a thousand successful batches: the next batch came back with a `backendError` and the run went to FAILED, discarding two and a half hours of work. The connector's `Max Fetch Retries` and `Initial Retry Delay` settings did not help, because they live in `AbstractSource` and only cover fetching from the upstream API, never the save into BigQuery.

# Solution

`executeQuery` now retries a failed query with exponential backoff before giving up. The retry sits there rather than in the MERGE loop because both failure points are inside it, and every job the storage runs — MERGE, table creation, column addition, schema reads — shares the same entry point and the same transient failure modes.

- **A retry reuses the job it already submitted.** Once `createQueryJob` resolves, the statement is with BigQuery; resubmitting would run the MERGE a second time, paying for the scan twice and letting two mutations of the same rows overlap. Only a failure that happened before a job existed sends a new one — which is the common case, since BigQuery reports a rejected job through `createQueryJob` itself.
- **What gets retried is deliberately narrow**: a reason allowlist (`backendError`, `internalError`, `jobBackendError`, `jobInternalError`, `rateLimitExceeded`) or a transport-level failure (5xx, `ECONNRESET`, `ETIMEDOUT`, `EAI_AGAIN`). A reason outside the list does not grant a retry but does not veto one either, so a transient fault whose reason we did not enumerate is still recovered. `invalidQuery`, `accessDenied` and `quotaExceeded` arrive with a 4xx and surface immediately.
- **The existing batch-halving path is untouched.** An oversized query is `invalidQuery` with status 400, so it is not retried and still reaches `executeMergeQueryRecursively` on the first attempt to halve the batch. Pinned by a test.
- **Settings are reused, not re-declared**, read with defaults so a storage built without them still works, and sanitised: config validation only checks `typeof value === 'number'`, and `NaN` passes that, which would have left the retry loop with an exit condition that is never true.
- **Backoff was extracted** to `AsyncUtils.backoffDelay`, since `AbstractSource.calculateBackoff` already implemented the identical formula. It is clamped to `setTimeout`'s maximum, because doubling passes that ceiling around the twentieth attempt and `setTimeout` then falls back to firing after 1ms — turning a long retry chain into a tight loop against the service it is backing off from. The clamp sits far above any usable configuration, so a delay a user configured is never shortened.
- Retry messages go through `config.logMessage`, so they appear in Run History, unlike the surrounding MERGE progress lines which use `console.log` and land as untyped output.

# Changes

- Added an attempt loop with exponential backoff to `GoogleBigQueryStorage.executeQuery`, holding the submitted job across attempts and rethrowing the original error once attempts are exhausted
- Added `_isRetryableBigQueryError` and `_bigQueryErrorReasons`, classifying failures by BigQuery reason code and by HTTP or network status
- Added `retrySettingOrDefault`, which falls back unless the configured value is a finite number, so a `NaN` retry count cannot produce an unbounded loop
- Added `AsyncUtils.backoffDelay`, clamped to `setTimeout`'s maximum, and pointed `AbstractSource.calculateBackoff` at it, removing the duplicated formula
- Added `test/Core/AsyncUtils.test.js` covering doubling, jitter, the clamp, overflow to `Infinity`, and that configured delays above a minute are honoured
- Added 17 storage tests covering retried and non-retried reasons, attempt limits, deterministic backoff, config fallbacks, `NaN` and sub-one retry counts, job reuse versus resubmission, and an end-to-end MERGE batch chain that recovers from a transient failure mid-chain
- Documented the retry behaviour in the Google BigQuery storage README
- Added changeset `6887-bigquery-retry-transient-merge-errors.md`