### PR TITLE
fix(canvas): prevent full-page errors in Model Canvas for larger data models

### DIFF
--- a/.changeset/6835-fix-canvas.md
+++ b/.changeset/6835-fix-canvas.md
@@ -1,0 +1,23 @@
+---
+'owox': minor
+---
+
+# Fix the Model Canvas failing with a full-page error on larger data models
+
+**Problem.** Opening the Model Canvas — or the Joinable Data Marts diagram — for a
+storage with many Data Marts and relationships could replace the whole page with a
+"Something went wrong" error screen right after the loading skeleton. Storages with
+only a few Data Marts were unaffected, so the failure was intermittent and hard to
+reproduce.
+
+**Cause.** The automatic layout step throws on some otherwise-valid relationship
+graphs — typically when a model has several relationships between the same pair of
+Data Marts, a Data Mart joined to itself, or circular joins. That error was not
+handled, so it propagated to the route error boundary and took down the entire page
+instead of just the canvas.
+
+**Fix.** The canvas now recovers instead of crashing. When the layout step fails it
+retries with a simplified view of the relationships, which resolves the vast
+majority of these cases and still produces a proper layout. If that also fails, it
+falls back to a plain grid you can rearrange by dragging. Node positions you set are
+still saved per storage.

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
@@ -56,6 +56,9 @@ export function ModelCanvasView({ onActiveQualityRunChange }: ModelCanvasViewPro
   const storageLoadGenerationRef = useRef(0);
   const mountedRef = useRef(false);
   const filters = useModelCanvasFilters();
+  // Destructured so the auto-select effect below can depend on the stable
+  // setter directly instead of the filters object, which is recreated each render.
+  const { setStorageId } = filters;
   const { navigate, scope, projectId } = useProjectRoute();
   const storageKnown =
     Boolean(filters.storageId) && dataStorages.some(s => s.id === filters.storageId);
@@ -97,8 +100,8 @@ export function ModelCanvasView({ onActiveQualityRunChange }: ModelCanvasViewPro
 
   useEffect(() => {
     if (storageKnown || dataStorages.length !== 1) return;
-    filters.setStorageId(dataStorages[0].id);
-  }, [storageKnown, dataStorages, filters.setStorageId]);
+    setStorageId(dataStorages[0].id);
+  }, [storageKnown, dataStorages, setStorageId]);
 
   const filteredTopology = useMemo(
     () => (topology ? filterCanvasData(topology, filters.status, filters.rel) : null),

--- a/apps/web/src/features/data-marts/shared/canvas/dagre-layout.test.ts
+++ b/apps/web/src/features/data-marts/shared/canvas/dagre-layout.test.ts
@@ -127,6 +127,40 @@ describe.each([
   });
 });
 
+it.each(['horizontal', 'vertical'] as const)(
+  'recovers a layout instead of throwing when Dagre cannot rank the raw graph (%s)',
+  direction => {
+    // Reduced from a real Models canvas that crashed the page: dense parallel
+    // edges (n3 -> n6 three times) converging with n2/n7 make Dagre place two
+    // connected nodes on the same point, and `dagre.layout` throws
+    // "Not possible to find intersection inside of the rectangle". The retry on
+    // the collapsed topology clears it.
+    const ids = ['n1', 'n2', 'n3', 'n6', 'n7'];
+    const nodes: DagreLayoutNode[] = ids.map(id => ({ id, width: NODE_W, height: NODE_H }));
+    const edges: DagreLayoutEdge[] = [
+      { id: 'e4', sourceId: 'n3', targetId: 'n6' },
+      { id: 'e10', sourceId: 'n7', targetId: 'n3' },
+      { id: 'e11', sourceId: 'n3', targetId: 'n6' },
+      { id: 'e13', sourceId: 'n1', targetId: 'n7' },
+      { id: 'e14', sourceId: 'n2', targetId: 'n6' },
+      { id: 'e15', sourceId: 'n3', targetId: 'n6' },
+      { id: 'e17', sourceId: 'n2', targetId: 'n7' },
+    ];
+
+    const result = runDagreLayout(nodes, edges, direction);
+
+    expect(result.positions.size).toBe(nodes.length);
+    for (const node of nodes) {
+      expect(result.positions.has(node.id)).toBe(true);
+    }
+    expect(uniquePositions(result.positions)).toBe(true);
+    for (const position of result.positions.values()) {
+      expect(Number.isFinite(position.x)).toBe(true);
+      expect(Number.isFinite(position.y)).toBe(true);
+    }
+  }
+);
+
 it('keeps a deep graph renderable when Dagre exhausts the call stack', () => {
   const nodes = Array.from({ length: 2_000 }, (_, index) => ({
     id: `node-${index}`,

--- a/apps/web/src/features/data-marts/shared/canvas/dagre-layout.ts
+++ b/apps/web/src/features/data-marts/shared/canvas/dagre-layout.ts
@@ -70,7 +70,26 @@ function buildFallbackPositions(
   return positions;
 }
 
-export function runDagreLayout(
+/**
+ * Only the edge topology drives dagre's ranking: parallel edges between the same
+ * ordered pair and self-loops add nothing to it, but they make dagre route extra
+ * dummy nodes that can land on a real node's centre and throw "Not possible to
+ * find intersection inside of the rectangle". Collapsing them is a safe retry.
+ */
+function simplifyEdgesForLayout(edges: DagreLayoutEdge[]): DagreLayoutEdge[] {
+  const seenPairs = new Set<string>();
+  const simplified: DagreLayoutEdge[] = [];
+  for (const edge of edges) {
+    if (edge.sourceId === edge.targetId) continue;
+    const pairKey = `${edge.sourceId} -> ${edge.targetId}`;
+    if (seenPairs.has(pairKey)) continue;
+    seenPairs.add(pairKey);
+    simplified.push(edge);
+  }
+  return simplified;
+}
+
+function layoutWithDagre(
   nodes: DagreLayoutNode[],
   edges: DagreLayoutEdge[],
   direction: CanvasDirection
@@ -78,8 +97,6 @@ export function runDagreLayout(
   const positions = new Map<string, PathPoint>();
   const routes = new Map<string, PathPoint[]>();
   const labelPositions = new Map<string, PathPoint>();
-
-  if (nodes.length === 0) return { positions, routes, labelPositions };
 
   const g = new dagre.graphlib.Graph<GraphLabel, NodeLabel, EdgeLabel>({ multigraph: true });
   g.setGraph({ rankdir: direction === 'horizontal' ? 'LR' : 'TB' });
@@ -96,16 +113,7 @@ export function runDagreLayout(
     g.setEdge(edge.sourceId, edge.targetId, edgeLabel, edge.id);
   }
 
-  try {
-    dagre.layout(g);
-  } catch (error) {
-    if (!(error instanceof RangeError)) throw error;
-    return {
-      positions: buildFallbackPositions(nodes, direction),
-      routes,
-      labelPositions,
-    };
-  }
+  dagre.layout(g);
 
   for (const nodeId of g.nodes()) {
     const n = g.node(nodeId);
@@ -114,6 +122,9 @@ export function runDagreLayout(
   }
 
   for (const edge of edges) {
+    // A collapsed retry graph (see `simplifyEdgesForLayout`) drops some edges,
+    // so the lookup can miss even though the type says otherwise.
+    if (!g.hasEdge(edge.sourceId, edge.targetId, edge.id)) continue;
     const ed = g.edge({ v: edge.sourceId, w: edge.targetId, name: edge.id });
 
     const interiorPoints = (ed.points ?? []).slice(1, -1);
@@ -125,4 +136,39 @@ export function runDagreLayout(
   }
 
   return { positions, routes, labelPositions };
+}
+
+export function runDagreLayout(
+  nodes: DagreLayoutNode[],
+  edges: DagreLayoutEdge[],
+  direction: CanvasDirection
+): DagreLayoutResult {
+  if (nodes.length === 0) {
+    return { positions: new Map(), routes: new Map(), labelPositions: new Map() };
+  }
+
+  try {
+    return layoutWithDagre(nodes, edges, direction);
+  } catch {
+    // Dagre throws on graphs it cannot rank cleanly: a RangeError when a deep
+    // graph exhausts its recursion, or a plain Error ("Not possible to find
+    // intersection inside of the rectangle") when dense parallel edges or
+    // cycles collapse two connected nodes onto one point. Retry once on the
+    // ranking-only topology, which clears most of these, before falling back to
+    // a deterministic grid: anything is better than the exception taking down
+    // the whole page.
+    const simplified = simplifyEdgesForLayout(edges);
+    if (simplified.length < edges.length) {
+      try {
+        return layoutWithDagre(nodes, simplified, direction);
+      } catch {
+        // fall through to the grid
+      }
+    }
+    return {
+      positions: buildFallbackPositions(nodes, direction),
+      routes: new Map(),
+      labelPositions: new Map(),
+    };
+  }
 }


### PR DESCRIPTION

<img width="1915" height="848" alt="image" src="https://github.com/user-attachments/assets/8bb2a2ad-c791-4903-8333-85fef509bccc" />

**Problem.** Opening the Model Canvas — or the Joinable Data Marts diagram — for a
storage with many Data Marts and relationships could replace the whole page with a
"Something went wrong" error screen right after the loading skeleton. Storages with
only a few Data Marts were unaffected, so the failure was intermittent and hard to
reproduce.

**Cause.** The automatic layout step throws on some otherwise-valid relationship
graphs — typically when a model has several relationships between the same pair of
Data Marts, a Data Mart joined to itself, or circular joins. That error was not
handled, so it propagated to the route error boundary and took down the entire page
instead of just the canvas.

**Fix.** The canvas now recovers instead of crashing. When the layout step fails it
retries with a simplified view of the relationships, which resolves the vast
majority of these cases and still produces a proper layout. If that also fails, it
falls back to a plain grid you can rearrange by dragging. Node positions you set are
still saved per storage.