### PR TITLE
fix: prevent truncated Data Studio responses

### DIFF
--- a/.changeset/6886-data-studio-large-response-truncation.md
+++ b/.changeset/6886-data-studio-large-response-truncation.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Prevent incomplete Data Studio responses for large reports
+
+Large Data Studio reports now return as many complete rows as fit within Apps Script response limits instead of ending with malformed JSON.

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
@@ -1,5 +1,5 @@
 import { Response } from 'express';
-import { PassThrough } from 'stream';
+import { PassThrough, Writable } from 'stream';
 import * as zlib from 'zlib';
 import { Test } from '@nestjs/testing';
 import { BigQueryFieldType } from '../../../data-storage-types/bigquery/enums/bigquery-field-type.enum';
@@ -185,6 +185,123 @@ describe('LookerStudioConnectorApiDataService', () => {
   });
 
   describe('streamData', () => {
+    it('reports the exact UTF-8 byte size of the JSON body', async () => {
+      const { res, chunks } = createMockResponse();
+
+      const context = {
+        schema: [{ name: 'emoji 🚀', dataType: FieldDataType.STRING }],
+        reader: {
+          readReportDataBatch: jest.fn().mockResolvedValue({
+            dataRows: [['Hello 😀']],
+            nextDataBatchId: null,
+          }),
+        },
+        fieldIndexMap: [0],
+        rowLimit: 1_000_000,
+      };
+
+      const streamResultPromise = service.streamData(res as Response, context as any);
+      await (res as any).waitForFinish();
+      const result = await streamResultPromise;
+      const body = zlib.gunzipSync(Buffer.concat(chunks));
+
+      expect(result.bytesWritten).toBe(body.byteLength);
+    });
+
+    it('does not write a UTF-8 row that would exceed the Apps Script response limit', async () => {
+      const { res, chunks } = createMockResponse();
+
+      const context = {
+        schema: [{ name: 'field1', dataType: FieldDataType.STRING }],
+        reader: {
+          readReportDataBatch: jest.fn().mockResolvedValue({
+            dataRows: [['kept'], ['🚀'.repeat(13_000_000)]],
+            nextDataBatchId: null,
+          }),
+        },
+        fieldIndexMap: [0],
+        rowLimit: 2,
+      };
+
+      const streamResultPromise = service.streamData(res as Response, context as any);
+      await (res as any).waitForFinish();
+      const result = await streamResultPromise;
+      const body = zlib.gunzipSync(Buffer.concat(chunks));
+
+      expect(result.limitExceeded).toBe(true);
+      expect(result.rowCount).toBe(1);
+      expect(body.byteLength).toBeLessThanOrEqual(49 * 1024 * 1024);
+      expect(JSON.parse(body.toString()).rows).toEqual([{ values: ['kept'] }]);
+    });
+
+    it('does not resolve before the compressed response finishes', async () => {
+      let releaseFirstWrite!: () => void;
+      let markFirstWriteStarted!: () => void;
+      const firstWriteStarted = new Promise<void>(resolve => {
+        markFirstWriteStarted = resolve;
+      });
+      let shouldBlockWrite = true;
+      const res = new Writable({
+        write(_chunk, _encoding, callback) {
+          if (shouldBlockWrite) {
+            shouldBlockWrite = false;
+            releaseFirstWrite = callback;
+            markFirstWriteStarted();
+            return;
+          }
+          callback();
+        },
+      }) as Writable & Partial<Response>;
+      res.setHeader = jest.fn().mockReturnThis();
+
+      const context = {
+        schema: [{ name: 'field1', dataType: FieldDataType.STRING }],
+        reader: {
+          readReportDataBatch: jest.fn().mockResolvedValue({
+            dataRows: [['value1']],
+            nextDataBatchId: null,
+          }),
+        },
+        fieldIndexMap: [0],
+        rowLimit: 1_000_000,
+      };
+
+      let resolved = false;
+      const resultPromise = service.streamData(res as Response, context as any).then(result => {
+        resolved = true;
+        return result;
+      });
+
+      await firstWriteStarted;
+      await Promise.resolve();
+
+      expect(resolved).toBe(false);
+      releaseFirstWrite();
+      await resultPromise;
+      expect(res.writableFinished).toBe(true);
+    });
+
+    it('rejects when the response closes while a batch is loading', async () => {
+      const res = new PassThrough() as PassThrough & Partial<Response>;
+      res.setHeader = jest.fn().mockReturnThis();
+      res.resume();
+
+      const context = {
+        schema: [{ name: 'field1', dataType: FieldDataType.STRING }],
+        reader: {
+          readReportDataBatch: jest.fn().mockImplementation(async () => {
+            res.destroy();
+            await new Promise(resolve => setImmediate(resolve));
+            return { dataRows: [], nextDataBatchId: null };
+          }),
+        },
+        fieldIndexMap: [0],
+        rowLimit: 1_000_000,
+      };
+
+      await expect(service.streamData(res as Response, context as any)).rejects.toThrow();
+    });
+
     it('should stream JSON response with correct structure', async () => {
       const { res, chunks, headers } = createMockResponse();
 

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
@@ -281,6 +281,69 @@ describe('LookerStudioConnectorApiDataService', () => {
       expect(res.writableFinished).toBe(true);
     });
 
+    it('rejects when the response closes during a backpressured gzip write', async () => {
+      let destinationWrites = 0;
+      let markBackpressured!: () => void;
+      const backpressured = new Promise<void>(resolve => {
+        markBackpressured = resolve;
+      });
+      let gzip!: zlib.Gzip;
+      const res = new Writable({
+        highWaterMark: 1,
+        write(_chunk, _encoding, callback) {
+          destinationWrites += 1;
+          if (destinationWrites === 1) {
+            callback();
+            return;
+          }
+          markBackpressured();
+        },
+      }) as Writable & Partial<Response>;
+      res.setHeader = jest.fn().mockReturnThis();
+      res.once('pipe', source => {
+        gzip = source as zlib.Gzip;
+      });
+
+      const context = {
+        schema: [{ name: 'field1', dataType: FieldDataType.STRING }],
+        reader: {
+          readReportDataBatch: jest.fn().mockResolvedValue({
+            dataRows: [[Array.from({ length: 100_000 }, (_, i) => i.toString(36)).join(',')]],
+            nextDataBatchId: null,
+          }),
+        },
+        fieldIndexMap: [0],
+        rowLimit: 1_000_000,
+      };
+
+      const resultPromise = service.streamData(res as Response, context as any);
+      await backpressured;
+      for (
+        let attempt = 0;
+        attempt < 100 && gzip.readableLength < gzip.readableHighWaterMark;
+        attempt += 1
+      ) {
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      expect(gzip.readableLength).toBeGreaterThanOrEqual(gzip.readableHighWaterMark);
+
+      let timeout: NodeJS.Timeout | undefined;
+      const completion = Promise.race([
+        resultPromise,
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => reject(new Error('streamData remained pending')), 1_000);
+        }),
+      ]);
+
+      res.destroy(new Error('client disconnected'));
+
+      try {
+        await expect(completion).rejects.toThrow('client disconnected');
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    });
+
     it('rejects when the response closes while a batch is loading', async () => {
       const res = new PassThrough() as PassThrough & Partial<Response>;
       res.setHeader = jest.fn().mockReturnThis();

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
@@ -318,14 +318,7 @@ describe('LookerStudioConnectorApiDataService', () => {
 
       const resultPromise = service.streamData(res as Response, context as any);
       await backpressured;
-      for (
-        let attempt = 0;
-        attempt < 100 && gzip.readableLength < gzip.readableHighWaterMark;
-        attempt += 1
-      ) {
-        await new Promise(resolve => setImmediate(resolve));
-      }
-      expect(gzip.readableLength).toBeGreaterThanOrEqual(gzip.readableHighWaterMark);
+      expect(gzip.writableLength).toBeGreaterThan(0);
 
       let timeout: NodeJS.Timeout | undefined;
       const completion = Promise.race([

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Response } from 'express';
+import { pipeline } from 'node:stream/promises';
 import * as zlib from 'zlib';
 import { BusinessViolationException } from '../../../../common/exceptions/business-violation.exception';
 import { DataStorageType } from '../../../data-storage-types/enums/data-storage-type.enum';
@@ -347,9 +348,20 @@ export class LookerStudioConnectorApiDataService {
     bytesWritten: number;
   }> {
     const { schema, reader, fieldIndexMap, rowLimit } = context;
+    const prefix = Buffer.from(`{"schema":${JSON.stringify(schema)},"rows":[`, 'utf8');
+    const suffix = Buffer.from(`],"filtersApplied":[]}`, 'utf8');
+
+    if (prefix.byteLength + suffix.byteLength > MAX_BYTES_LIMIT) {
+      throw new BusinessViolationException(
+        `Looker Studio response schema exceeds the size limit (${MAX_BYTES_LIMIT} bytes)`
+      );
+    }
+
+    if (res.closed) {
+      throw new Error('Streaming aborted: response closed');
+    }
 
     const gzip = zlib.createGzip({ level: 3 });
-    gzip.setDefaultEncoding('utf-8');
 
     // Set headers for JSON streaming
     res.setHeader('Content-Type', 'application/json');
@@ -357,86 +369,103 @@ export class LookerStudioConnectorApiDataService {
     res.setHeader('Transfer-Encoding', 'chunked');
     res.setHeader('X-Accel-Buffering', 'no');
 
-    // Pipe gzip stream to response
-    gzip.pipe(res);
-
-    // Write opening JSON structure with schema
-    gzip.write(`{"schema":${JSON.stringify(schema)},"rows":[`);
+    const streamCompletion = pipeline(gzip, res);
+    streamCompletion.catch(() => undefined);
 
     let totalRows = 0;
-    let isFirstBatch = true;
+    let bytesWritten = prefix.byteLength;
     let nextBatchId: string | undefined | null = undefined;
     let limitExceeded = false;
     let limitReason: string | undefined;
 
-    do {
-      if (res.closed) {
-        this.logger.warn('Streaming aborted: response closed');
-        break;
-      }
+    try {
+      await this.writeGzipChunk(gzip, prefix);
 
-      const remainingRows = rowLimit - totalRows;
-      const batchSize = Math.min(STREAMING_BATCH_SIZE, remainingRows);
-
-      const batch = await reader.readReportDataBatch(nextBatchId, batchSize);
-
-      // Format all rows in the batch
-      const rowsToWrite = Math.min(batch.dataRows.length, rowLimit - totalRows);
-      const formattedRows: DataRow[] = [];
-
-      for (let i = 0; i < rowsToWrite; i++) {
-        formattedRows.push({
-          values: fieldIndexMap.map(index => this.convertToFieldValue(batch.dataRows[i][index])),
-        });
-      }
-
-      // Write entire batch as single chunk (much faster than row-by-row)
-      if (formattedRows.length > 0) {
-        const batchJson = formattedRows.map(row => JSON.stringify(row)).join(',');
-        gzip.write(isFirstBatch ? batchJson : ',' + batchJson);
-        isFirstBatch = false;
-        totalRows += formattedRows.length;
-      }
-
-      nextBatchId = batch.nextDataBatchId;
-
-      // Check if we've reached the row limit
-      if (totalRows >= rowLimit) {
-        if (nextBatchId) {
-          const limitType = rowLimit < MAX_ROWS_LIMIT ? 'sample extraction' : 'full extraction';
-          this.logger.warn(
-            `Row limit reached during streaming (${limitType}): returned ${totalRows} rows (more data available)`
-          );
-          limitExceeded = true;
-          limitReason = `Row limit reached (${rowLimit} rows)`;
+      do {
+        if (res.closed) {
+          throw new Error('Streaming aborted: response closed');
         }
-        break;
-      }
 
-      if (gzip.bytesWritten >= MAX_BYTES_LIMIT) {
-        if (nextBatchId) {
-          this.logger.warn(
-            `Size limit reached during streaming: returned ${totalRows} rows, data size: ${gzip.bytesWritten} bytes`
-          );
+        const remainingRows = rowLimit - totalRows;
+        const batchSize = Math.min(STREAMING_BATCH_SIZE, remainingRows);
+
+        const batch = await reader.readReportDataBatch(nextBatchId, batchSize);
+        if (res.closed) {
+          throw new Error('Streaming aborted: response closed');
         }
-        limitExceeded = true;
-        limitReason = limitReason ?? `Size limit reached (${MAX_BYTES_LIMIT} bytes gzipped)`;
-        break;
-      }
-    } while (nextBatchId);
 
-    // Write closing JSON structure
-    gzip.write(`],"filtersApplied":[]}`);
-    gzip.end();
+        const rowsToWrite = Math.min(batch.dataRows.length, rowLimit - totalRows);
+        const batchJson: string[] = [];
+
+        for (let i = 0; i < rowsToWrite; i++) {
+          const row: DataRow = {
+            values: fieldIndexMap.map(index => this.convertToFieldValue(batch.dataRows[i][index])),
+          };
+          const serializedRow = `${totalRows === 0 ? '' : ','}${JSON.stringify(row)}`;
+          const rowBytes = Buffer.byteLength(serializedRow, 'utf8');
+
+          if (bytesWritten + rowBytes + suffix.byteLength > MAX_BYTES_LIMIT) {
+            limitExceeded = true;
+            limitReason = `Size limit reached (${MAX_BYTES_LIMIT} bytes)`;
+            break;
+          }
+
+          batchJson.push(serializedRow);
+          bytesWritten += rowBytes;
+          totalRows += 1;
+        }
+
+        if (batchJson.length > 0) {
+          await this.writeGzipChunk(gzip, Buffer.from(batchJson.join(''), 'utf8'));
+        }
+
+        nextBatchId = batch.nextDataBatchId;
+
+        if (limitExceeded) {
+          this.logger.warn(
+            `Size limit reached during streaming: returned ${totalRows} rows, data size: ${bytesWritten} bytes`
+          );
+          break;
+        }
+
+        if (totalRows >= rowLimit) {
+          const hasMoreData = Boolean(nextBatchId) || batch.dataRows.length > rowsToWrite;
+          if (hasMoreData) {
+            const limitType = rowLimit < MAX_ROWS_LIMIT ? 'sample extraction' : 'full extraction';
+            this.logger.warn(
+              `Row limit reached during streaming (${limitType}): returned ${totalRows} rows (more data available)`
+            );
+            limitExceeded = true;
+            limitReason = `Row limit reached (${rowLimit} rows)`;
+          }
+          break;
+        }
+      } while (nextBatchId);
+
+      await this.writeGzipChunk(gzip, suffix);
+      bytesWritten += suffix.byteLength;
+      gzip.end();
+      await streamCompletion;
+    } catch (error) {
+      gzip.destroy();
+      await streamCompletion.catch(() => undefined);
+      throw error;
+    }
 
     this.logger.log(
-      `Streaming completed: ${totalRows} rows sent, data size: ${gzip.bytesWritten} bytes`
+      `Streaming completed: ${totalRows} rows sent, data size: ${bytesWritten} bytes`
     );
     return {
       rowCount: totalRows,
       limitExceeded,
       limitReason,
-      bytesWritten: gzip.bytesWritten,
+      bytesWritten,
     };
+  }
+
+  private writeGzipChunk(gzip: zlib.Gzip, chunk: Buffer): Promise<void> {
+    return new Promise((resolve, reject) => {
+      gzip.write(chunk, error => (error ? reject(error) : resolve()));
+    });
   }
 }

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.ts
@@ -379,7 +379,7 @@ export class LookerStudioConnectorApiDataService {
     let limitReason: string | undefined;
 
     try {
-      await this.writeGzipChunk(gzip, prefix);
+      await this.writeGzipChunk(gzip, prefix, streamCompletion);
 
       do {
         if (res.closed) {
@@ -416,7 +416,11 @@ export class LookerStudioConnectorApiDataService {
         }
 
         if (batchJson.length > 0) {
-          await this.writeGzipChunk(gzip, Buffer.from(batchJson.join(''), 'utf8'));
+          await this.writeGzipChunk(
+            gzip,
+            Buffer.from(batchJson.join(''), 'utf8'),
+            streamCompletion
+          );
         }
 
         nextBatchId = batch.nextDataBatchId;
@@ -442,7 +446,7 @@ export class LookerStudioConnectorApiDataService {
         }
       } while (nextBatchId);
 
-      await this.writeGzipChunk(gzip, suffix);
+      await this.writeGzipChunk(gzip, suffix, streamCompletion);
       bytesWritten += suffix.byteLength;
       gzip.end();
       await streamCompletion;
@@ -463,9 +467,16 @@ export class LookerStudioConnectorApiDataService {
     };
   }
 
-  private writeGzipChunk(gzip: zlib.Gzip, chunk: Buffer): Promise<void> {
-    return new Promise((resolve, reject) => {
-      gzip.write(chunk, error => (error ? reject(error) : resolve()));
-    });
+  private writeGzipChunk(
+    gzip: zlib.Gzip,
+    chunk: Buffer,
+    streamCompletion: Promise<void>
+  ): Promise<void> {
+    return Promise.race([
+      new Promise<void>((resolve, reject) => {
+        gzip.write(chunk, error => (error ? reject(error) : resolve()));
+      }),
+      streamCompletion,
+    ]);
   }
 }


### PR DESCRIPTION
## Summary

Prevents large Data Studio report responses from being cut off as invalid JSON near the Apps Script URL Fetch response-size limit. The backend now returns only complete rows that fit within the configured response budget and finishes processing the report only after the compressed HTTP response completes.

## Problem

Large reports could fail in the Data Studio connector with an error such as:

```text
SyntaxError: Unterminated string in JSON at position 52401192
```

At the same time, the backend could log the report as successfully completed. The connector and backend therefore disagreed about the outcome of the same request.

### Example

If a response was already close to the 50 MB Apps Script limit, the backend could enqueue another batch of up to 5,000 rows. Apps Script could then truncate the response in the middle of a value:

```json
{"values":["an incomplete value
```

The connector could not parse that response, although the backend had already continued through its success flow.

## Root cause

The streaming implementation used `gzip.bytesWritten` as an immediate response-size counter after calling `gzip.write()`. That value reflects data processed asynchronously by the compression stream, so it could lag behind the data already queued for writing.

The size guard also ran only after an entire batch had been written and did not reserve space for the closing JSON structure. As a result, a batch could cross the limit before the backend detected it.

Finally, `streamData()` returned immediately after `gzip.end()` instead of waiting for the gzip and HTTP streams to finish. This allowed report success handling to run before delivery was actually complete.

## Solution

- Track the exact UTF-8 size of the JSON response independently of gzip state.
- Check each serialized row before writing it, including its separator and the reserved closing JSON structure.
- Stop at the last complete row that fits, then close the JSON normally.
- Await gzip writes and the complete HTTP pipeline so stream failures propagate to report-run handling.

This approach enforces the limit before data is written. Simply reducing the batch size or lowering the threshold would only reduce the likelihood of an overrun because row and batch sizes are variable. Using Node's stream pipeline also provides a single completion and error boundary for both gzip and the HTTP response.

## Test plan

- [x] Verify exact response-size accounting for UTF-8 JSON.
- [x] Verify that a row exceeding the remaining budget is not partially written and the response remains valid JSON.
- [x] Verify that `streamData()` does not resolve before the compressed response finishes.
- [x] Verify that a closed response rejects the streaming operation.
- [x] Backend unit suite: 9,433 tests passed.
- [x] Data Studio API E2E suite: 23 tests passed with streaming enabled.
- [x] Backend build, ESLint, Prettier, and changeset validation.
