### PR TITLE
fix: surface Data Studio schema query errors

### DIFF
--- a/.changeset/6919-data-studio-schema-query-errors.md
+++ b/.changeset/6919-data-studio-schema-query-errors.md
@@ -4,4 +4,4 @@
 
 # Show Data Studio query errors during connection
 
-Data Studio now shows troubleshooting guidance and the underlying query error when loading a Data Mart schema fails instead of suggesting that the deployment URL is incorrect.
+Data Studio now shows troubleshooting guidance and the underlying query error when loading a Data Mart schema or its data fails instead of suggesting that the deployment URL is incorrect.

--- a/.changeset/6919-data-studio-schema-query-errors.md
+++ b/.changeset/6919-data-studio-schema-query-errors.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Show Data Studio query errors during connection
+
+Data Studio now shows troubleshooting guidance and the underlying query error when loading a Data Mart schema fails instead of suggesting that the deployment URL is incorrect.

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
@@ -2,12 +2,14 @@ import { Response } from 'express';
 import { Report } from '../../../entities/report.entity';
 import { GetDataRequest } from '../schemas/get-data.schema';
 import { GetSchemaRequest } from '../schemas/get-schema.schema';
+import { BusinessViolationException } from '../../../../common/exceptions/business-violation.exception';
 import { ProjectOperationBlockedException } from '../../../../common/exceptions/project-operation-blocked.exception';
 import { ProjectBlockedReason } from '../../../enums/project-blocked-reason.enum';
 
 // Mock external modules before importing service
 jest.mock('@owox/internal-helpers', () => ({
   createProducer: jest.fn(),
+  castError: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),
   BaseEvent: class {
     constructor(public payload: unknown) {}
   },
@@ -174,6 +176,40 @@ describe('LookerStudioConnectorApiService', () => {
 
       expect(projectBilling.verifyCanPerformOperations).not.toHaveBeenCalled();
       expect(schemaService.getSchema).toHaveBeenCalledWith(request, report, cachedReader);
+    });
+
+    it('logs cached reader failures with report context', async () => {
+      const request = createMockSchemaRequest();
+      const report = createMockReport();
+      const queryError = new Error('Query execution failed');
+      reportService.getByIdAndLookerStudioSecret.mockResolvedValue(report);
+      cacheService.getOrCreateCachedReader.mockRejectedValue(queryError);
+
+      await expect(service.getSchema(request)).rejects.toThrow('Query execution failed');
+
+      expect((service as any).logger.error).toHaveBeenCalledWith(
+        'Failed to read Data Mart data for Looker Studio: Query execution failed',
+        queryError.stack,
+        {
+          reportId: 'report-1',
+          dataMartId: 'datamart-1',
+          projectId: 'project-1',
+        }
+      );
+    });
+
+    it('preserves cached reader business errors with their code and details', async () => {
+      const request = createMockSchemaRequest();
+      const report = createMockReport();
+      const queryError = new BusinessViolationException(
+        'Query execution failed',
+        { reason: 'missing column' },
+        'QUERY_EXECUTION_FAILED'
+      );
+      reportService.getByIdAndLookerStudioSecret.mockResolvedValue(report);
+      cacheService.getOrCreateCachedReader.mockRejectedValue(queryError);
+
+      await expect(service.getSchema(request)).rejects.toBe(queryError);
     });
   });
 

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
@@ -3,13 +3,13 @@ import { Report } from '../../../entities/report.entity';
 import { GetDataRequest } from '../schemas/get-data.schema';
 import { GetSchemaRequest } from '../schemas/get-schema.schema';
 import { BusinessViolationException } from '../../../../common/exceptions/business-violation.exception';
+import { DataMartReadFailedException } from '../../../errors/data-mart-read-failed.error';
 import { ProjectOperationBlockedException } from '../../../../common/exceptions/project-operation-blocked.exception';
 import { ProjectBlockedReason } from '../../../enums/project-blocked-reason.enum';
 
 // Mock external modules before importing service
 jest.mock('@owox/internal-helpers', () => ({
   createProducer: jest.fn(),
-  castError: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),
   BaseEvent: class {
     constructor(public payload: unknown) {}
   },
@@ -178,24 +178,16 @@ describe('LookerStudioConnectorApiService', () => {
       expect(schemaService.getSchema).toHaveBeenCalledWith(request, report, cachedReader);
     });
 
-    it('logs cached reader failures with report context', async () => {
+    it('does not duplicate-log a cached reader failure already logged by the cache service', async () => {
       const request = createMockSchemaRequest();
       const report = createMockReport();
-      const queryError = new Error('Query execution failed');
+      const queryError = new DataMartReadFailedException(new Error('Query execution failed'));
       reportService.getByIdAndLookerStudioSecret.mockResolvedValue(report);
       cacheService.getOrCreateCachedReader.mockRejectedValue(queryError);
 
-      await expect(service.getSchema(request)).rejects.toThrow('Query execution failed');
+      await expect(service.getSchema(request)).rejects.toBe(queryError);
 
-      expect((service as any).logger.error).toHaveBeenCalledWith(
-        'Failed to read Data Mart data for Looker Studio: Query execution failed',
-        queryError.stack,
-        {
-          reportId: 'report-1',
-          dataMartId: 'datamart-1',
-          projectId: 'project-1',
-        }
-      );
+      expect((service as any).logger.error).not.toHaveBeenCalled();
     });
 
     it('preserves cached reader business errors with their code and details', async () => {
@@ -204,12 +196,35 @@ describe('LookerStudioConnectorApiService', () => {
       const queryError = new BusinessViolationException(
         'Query execution failed',
         { reason: 'missing column' },
-        'QUERY_EXECUTION_FAILED'
+        'ANY_CODE'
       );
       reportService.getByIdAndLookerStudioSecret.mockResolvedValue(report);
       cacheService.getOrCreateCachedReader.mockRejectedValue(queryError);
 
       await expect(service.getSchema(request)).rejects.toBe(queryError);
+      expect((service as any).logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getData', () => {
+    it('stores the original reader failure while returning connector guidance', async () => {
+      const request = createMockRequest();
+      const report = createMockReport();
+      const originalError = new Error('Query execution failed');
+      const connectorError = new DataMartReadFailedException(originalError);
+      const reportRun = {
+        markAsUnsuccessful: jest.fn(),
+        getReport: jest.fn().mockReturnValue(report),
+        getReportId: jest.fn().mockReturnValue('report-1'),
+      };
+      reportService.getByIdAndLookerStudioSecret.mockResolvedValue(report);
+      reportRunService.create.mockResolvedValue(reportRun as never);
+      cacheService.getOrCreateCachedReader.mockRejectedValue(connectorError);
+
+      await expect(service.getData(request)).rejects.toBe(connectorError);
+
+      expect(reportRun.markAsUnsuccessful).toHaveBeenCalledWith(originalError);
+      expect((service as any).logger.error).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
-import { castError } from '@owox/internal-helpers';
 import { Response } from 'express';
 import { BusinessViolationException } from '../../../../common/exceptions/business-violation.exception';
 import { ProjectOperationBlockedException } from '../../../../common/exceptions/project-operation-blocked.exception';
@@ -7,6 +6,7 @@ import { OwoxEventDispatcher } from '../../../../common/event-dispatcher/owox-ev
 import { SystemTimeService } from '../../../../common/scheduler/services/system-time.service';
 import { CachedReaderData } from '../../../dto/domain/cached-reader-data.dto';
 import { Report } from '../../../entities/report.entity';
+import { DataMartReadFailedException } from '../../../errors/data-mart-read-failed.error';
 import { LookerReportRunEvent } from '../../../events/looker-report-run.event';
 import { LookerStudioReportRun } from '../../../models/looker-studio-report-run.model';
 import { logBlendedSqlIfNeeded } from '../../../report-run-logging/log-blended-sql';
@@ -272,28 +272,7 @@ export class LookerStudioConnectorApiService {
       report.createdById
     );
 
-    try {
-      return await this.cacheService.getOrCreateCachedReader(report, accessor);
-    } catch (error) {
-      const cause = castError(error);
-      this.logger.error(
-        `Failed to read Data Mart data for Looker Studio: ${cause.message}`,
-        cause.stack,
-        {
-          reportId: report.id,
-          dataMartId: report.dataMart.id,
-          projectId: report.dataMart.projectId,
-        }
-      );
-      if (error instanceof BusinessViolationException) {
-        throw error;
-      }
-      throw new BusinessViolationException(
-        'Failed to read data from this Data Mart. ' +
-          'Check the Data Mart query and storage access, or contact the Data Mart owner. ' +
-          `Details: ${cause.message}`
-      );
-    }
+    return this.cacheService.getOrCreateCachedReader(report, accessor);
   }
 
   /**
@@ -365,7 +344,9 @@ export class LookerStudioConnectorApiService {
       const { response } = await this.dataService.getData(request, report, cachedReader, true);
       return response;
     } catch (error) {
-      this.logger.error('Failed to get sample data:', error);
+      if (!(error instanceof DataMartReadFailedException)) {
+        this.logger.error('Failed to get sample data:', error);
+      }
       throw error;
     }
   }
@@ -505,11 +486,13 @@ export class LookerStudioConnectorApiService {
     error: Error | string,
     reportRunLogger?: ReportRunLogger
   ) {
-    reportRun.markAsUnsuccessful(error);
+    reportRun.markAsUnsuccessful(
+      error instanceof DataMartReadFailedException ? error.cause : error
+    );
     await this.saveReportRunResultSafely(reportRun, reportRunLogger);
     if (error instanceof ProjectOperationBlockedException) {
       this.logger.warn(`Report ${reportRun.getReportId()} execution restricted: ${error.message}`);
-    } else {
+    } else if (!(error instanceof DataMartReadFailedException)) {
       this.logger.error(`Report ${reportRun.getReportId()} execution failed:`, error);
     }
 

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { castError } from '@owox/internal-helpers';
 import { Response } from 'express';
 import { BusinessViolationException } from '../../../../common/exceptions/business-violation.exception';
 import { ProjectOperationBlockedException } from '../../../../common/exceptions/project-operation-blocked.exception';
@@ -271,7 +272,28 @@ export class LookerStudioConnectorApiService {
       report.createdById
     );
 
-    return this.cacheService.getOrCreateCachedReader(report, accessor);
+    try {
+      return await this.cacheService.getOrCreateCachedReader(report, accessor);
+    } catch (error) {
+      const cause = castError(error);
+      this.logger.error(
+        `Failed to read Data Mart data for Looker Studio: ${cause.message}`,
+        cause.stack,
+        {
+          reportId: report.id,
+          dataMartId: report.dataMart.id,
+          projectId: report.dataMart.projectId,
+        }
+      );
+      if (error instanceof BusinessViolationException) {
+        throw error;
+      }
+      throw new BusinessViolationException(
+        'Failed to read data from this Data Mart. ' +
+          'Check the Data Mart query and storage access, or contact the Data Mart owner. ' +
+          `Details: ${cause.message}`
+      );
+    }
   }
 
   /**

--- a/apps/backend/src/data-marts/errors/data-mart-read-failed.error.ts
+++ b/apps/backend/src/data-marts/errors/data-mart-read-failed.error.ts
@@ -1,0 +1,13 @@
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+
+export class DataMartReadFailedException extends BusinessViolationException {
+  constructor(readonly cause: Error) {
+    super(
+      'Failed to read data from this Data Mart. ' +
+        'Check the Data Mart query and storage access, or contact the Data Mart owner. ' +
+        `Details: ${cause.message}`,
+      undefined,
+      'DATA_MART_READ_FAILED'
+    );
+  }
+}

--- a/apps/backend/src/data-marts/services/report-data-cache.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.spec.ts
@@ -1,3 +1,6 @@
+import { BadRequestException } from '@nestjs/common';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { DataMartReadFailedException } from '../errors/data-mart-read-failed.error';
 import { ReportDataCacheService } from './report-data-cache.service';
 import { Report } from '../entities/report.entity';
 import { BlendingDecision } from '../dto/domain/blending-decision.dto';
@@ -53,7 +56,13 @@ describe('ReportDataCacheService — output controls on the cached path', () => 
       reportSqlComposerService as never
     );
 
-    return { service, reader, reportSqlComposerService, blendedReportDataService };
+    return {
+      service,
+      reader,
+      cacheRepository,
+      reportSqlComposerService,
+      blendedReportDataService,
+    };
   };
 
   const optionsPassedToReader = (reader: {
@@ -176,6 +185,81 @@ describe('ReportDataCacheService — output controls on the cached path', () => 
 
     expect(reportSqlComposerService.inlineStaticSql).not.toHaveBeenCalled();
     expect(cached.executionSqlQuery).toBeUndefined();
+  });
+
+  it('reports an initial reader failure with guidance while retaining the original cause', async () => {
+    const { service, reader } = setup({ needsBlending: false, columnFilter: ['a'] });
+    const queryError = new Error('Query execution failed: missing_column cannot be resolved');
+    const logger = {
+      debug: jest.fn(),
+      error: jest.fn(),
+      log: jest.fn(),
+      warn: jest.fn(),
+    };
+    (service as unknown as { logger: typeof logger }).logger = logger;
+    reader.readReportDataBatch.mockRejectedValue(queryError);
+
+    const failure = await service
+      .getOrCreateCachedReader(buildReport(), { userId: 'user-1', roles: ['editor'] } as never)
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(DataMartReadFailedException);
+    expect(failure).toMatchObject({
+      code: 'DATA_MART_READ_FAILED',
+      message:
+        'Failed to read data from this Data Mart. Check the Data Mart query and storage access, or contact the Data Mart owner. Details: Query execution failed: missing_column cannot be resolved',
+      cause: queryError,
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to read Data Mart data while creating a cached reader: Query execution failed: missing_column cannot be resolved',
+      queryError.stack,
+      {
+        reportId: 'rep-1',
+        dataMartId: 'dm-1',
+        projectId: 'proj-1',
+      }
+    );
+  });
+
+  it.each([
+    [
+      'business error',
+      new BusinessViolationException('Invalid report configuration', { field: 'country' }),
+    ],
+    [
+      'HTTP error',
+      new BadRequestException({
+        message: 'Pre-join filters are only applicable to joined data marts',
+        details: { errors: [{ code: 'PRE_JOIN_FILTERS_REQUIRE_JOINED_DATA_MART' }] },
+      }),
+    ],
+  ])('preserves a reader %s', async (_label, readerError) => {
+    const { service, reader } = setup({ needsBlending: false, columnFilter: ['a'] });
+    reader.prepareReportData.mockRejectedValue(readerError);
+
+    await expect(
+      service.getOrCreateCachedReader(buildReport(), {
+        userId: 'user-1',
+        roles: ['editor'],
+      } as never)
+    ).rejects.toBe(readerError);
+  });
+
+  it('does not present a cache persistence failure as a Data Mart read failure', async () => {
+    const { service, cacheRepository } = setup({
+      needsBlending: false,
+      columnFilter: ['a'],
+    });
+    const persistenceError = new Error('database is unavailable');
+    cacheRepository.save.mockRejectedValue(persistenceError);
+
+    await expect(
+      service.getOrCreateCachedReader(buildReport(), {
+        userId: 'user-1',
+        roles: ['editor'],
+      } as never)
+    ).rejects.toBe(persistenceError);
   });
 
   it('exposes inlined executionSqlQuery for a blended report with params', async () => {

--- a/apps/backend/src/data-marts/services/report-data-cache.service.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Inject, Logger } from '@nestjs/common';
+import { HttpException, Injectable, Inject, Logger } from '@nestjs/common';
+import { castError } from '@owox/internal-helpers';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { FindOptionsWhere, Repository, MoreThan, LessThan } from 'typeorm';
@@ -20,6 +21,8 @@ import { hasOutputControls } from '../dto/domain/report-like-read-plan';
 import { hasMainUniqueCount } from '../dto/schemas/unique-count-sources';
 import { ReportSqlComposerService } from './report-sql-composer.service';
 import { columnFilterWithoutCalculatedFields } from '../calculated-fields/calculated-field.utils';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { DataMartReadFailedException } from '../errors/data-mart-read-failed.error';
 
 /**
  * Service for managing persistent cache of report data readers
@@ -171,8 +174,28 @@ export class ReportDataCacheService {
     this.logger.debug(`Cache miss for report ${report.id}, creating new reader`);
 
     const reader = await this.readerResolver.resolve(report.dataMart.storage.type);
-    const dataDescription = await reader.prepareReportData(report, options);
-    await reader.readReportDataBatch(undefined, 1);
+    let dataDescription: CachedReaderData['dataDescription'];
+    try {
+      dataDescription = await reader.prepareReportData(report, options);
+      await reader.readReportDataBatch(undefined, 1);
+    } catch (error) {
+      if (error instanceof BusinessViolationException || error instanceof HttpException) {
+        throw error;
+      }
+
+      const cause = castError(error);
+      this.logger.error(
+        `Failed to read Data Mart data while creating a cached reader: ${cause.message}`,
+        cause.stack,
+        {
+          reportId: report.id,
+          dataMartId: report.dataMart.id,
+          projectId: report.dataMart.projectId,
+        }
+      );
+
+      throw new DataMartReadFailedException(cause);
+    }
     const readerState = reader.getState();
 
     const cacheLifetime = this.getCacheLifetime(report);

--- a/apps/backend/test/looker-studio-connector.e2e-spec.ts
+++ b/apps/backend/test/looker-studio-connector.e2e-spec.ts
@@ -284,6 +284,28 @@ describe('Looker Studio Connector (e2e)', () => {
       expect(revenueField.dataType).toBe('NUMBER');
     });
 
+    it('returns guidance and the query error when cached reader creation fails', async () => {
+      mockCacheService.getOrCreateCachedReader.mockRejectedValueOnce(
+        new Error('Query execution failed: Column missing_field cannot be resolved')
+      );
+
+      const res = await postLooker('/api/external/looker/get-schema', {
+        connectionConfig: {
+          deploymentUrl: 'http://localhost',
+          destinationId,
+          destinationSecretKey,
+        },
+        request: {
+          configParams: { destinationId, reportId },
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe(
+        'Failed to read data from this Data Mart. Check the Data Mart query and storage access, or contact the Data Mart owner. Details: Query execution failed: Column missing_field cannot be resolved'
+      );
+    });
+
     // LS-05
     // Flow: JWT → OK → validateAndExtractRequestData() → OK
     //   → ReportService.getByIdAndLookerStudioSecret('non-existent', secret) → null

--- a/apps/backend/test/looker-studio-connector.e2e-spec.ts
+++ b/apps/backend/test/looker-studio-connector.e2e-spec.ts
@@ -22,6 +22,7 @@ import { AggregateFunction } from '../src/data-marts/dto/schemas/aggregate-funct
 import { FieldDataType } from '../src/data-marts/data-destination-types/looker-studio-connector/enums/field-data-type.enum';
 import { FieldConceptType } from '../src/data-marts/data-destination-types/looker-studio-connector/enums/field-concept-type.enum';
 import { AggregationType } from '../src/data-marts/data-destination-types/looker-studio-connector/enums/aggregation-type.enum';
+import { DataMartReadFailedException } from '../src/data-marts/errors/data-mart-read-failed.error';
 
 // ---------------------------------------------------------------------------
 // Mock data for the in-memory reader
@@ -286,7 +287,9 @@ describe('Looker Studio Connector (e2e)', () => {
 
     it('returns guidance and the query error when cached reader creation fails', async () => {
       mockCacheService.getOrCreateCachedReader.mockRejectedValueOnce(
-        new Error('Query execution failed: Column missing_field cannot be resolved')
+        new DataMartReadFailedException(
+          new Error('Query execution failed: Column missing_field cannot be resolved')
+        )
       );
 
       const res = await postLooker('/api/external/looker/get-schema', {
@@ -304,6 +307,7 @@ describe('Looker Studio Connector (e2e)', () => {
       expect(res.body.message).toBe(
         'Failed to read data from this Data Mart. Check the Data Mart query and storage access, or contact the Data Mart owner. Details: Query execution failed: Column missing_field cannot be resolved'
       );
+      expect(res.body.code).toBe('DATA_MART_READ_FAILED');
     });
 
     // LS-05


### PR DESCRIPTION
# Summary

Makes query failures during Data Studio connector setup understandable and relevant to the user. Instead of reporting a generic deployment URL problem, Data Studio now shows guidance together with the original Data Mart query error.

This change does not suppress, recover from, or otherwise hide the underlying failure. The schema request still fails when the Data Mart query cannot be executed; the failure is returned through the connector's supported error contract so the user can act on the actual cause.

## Problem

When a user connects a Data Mart to Data Studio, the connector requests the report schema. To produce that schema, the backend creates or restores a cached report reader and executes the initial query batch.

If query preparation or execution failed in `ReportDataCacheService.createNewCachedReader`, Data Studio displayed a generic connection error suggesting that the deployment URL should be checked. That message was misleading when the URL and connector deployment were valid and the real problem was the Data Mart query or storage access.

## Root cause

Errors from the cached-reader path propagated as unhandled exceptions. The backend therefore returned HTTP 500 for a failed schema request.

The Data Studio connector only extracts and displays the backend's structured error message for HTTP 400 responses. For other HTTP statuses, including 500, it intentionally falls back to a generic message about being unable to connect to the server and checking the deployment URL.

The query error was therefore not lost inside the warehouse or fixed by retrying: it crossed the backend boundary with a status the connector treats as an infrastructure failure, so the connector replaced the relevant query message with unrelated deployment guidance.

## Solution

- Catch cached-reader failures at the shared Looker Studio API boundary.
- Preserve existing `BusinessViolationException` instances unchanged, including their message, code, and details.
- Convert other reader failures into an HTTP 400 business error with actionable guidance and the original error message:

  ```text
  Failed to read data from this Data Mart. Check the Data Mart query and storage access, or contact the Data Mart owner. Details: <original error message>
  ```

- Log the original failure server-side with its stack trace, `reportId`, `dataMartId`, and `projectId` for proactive diagnosis.

The backend does not return a fake schema, swallow the exception, or claim that the query succeeded. It keeps the failure visible while presenting it in a form that is meaningful to both Data Studio and the user.

## Data Studio screenshots

### Before

> <img width="898" height="577" alt="CleanShot 2026-09-08 at 15 35 30" src="https://github.com/user-attachments/assets/6d26d560-1140-4d4e-bfb3-7a99265a31d6" />

### After

> <img width="894" height="571" alt="CleanShot 2026-09-08 at 15 57 19" src="https://github.com/user-attachments/assets/f61bfc2f-e4bd-4615-ace7-0049baab90fa" />

## Test plan

- [x] Verify that an unknown cached-reader failure returns HTTP 400 with guidance and the original query error.
- [x] Verify that cached-reader failures are logged with the original stack trace and report context.
- [x] Verify that an existing `BusinessViolationException` is rethrown unchanged with its code and details.
- [x] Looker Studio API E2E suite: 24 tests passed.
- [x] Backend unit suite: 9,436 tests passed across 613 suites.
- [x] Backend build, ESLint, Prettier, markdownlint, and `git diff --check` passed.
