### PR TITLE
feat(web): link the OWOX add-in for Excel from the empty reports state

### DIFF
--- a/.changeset/6940-excel-add-in-link.md
+++ b/.changeset/6940-excel-add-in-link.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Open the OWOX add-in for Excel straight from the Destinations tab
+
+A Data Mart that has no Microsoft Excel reports yet now links to the OWOX add-in for Excel, so a business user reaches the place an Excel report is actually created in a single step instead of being told where to look. The Excel destination's description also links to the installation guide, for organizations that install the add-in manually.

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/descriptions/ExcelDescription.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/descriptions/ExcelDescription.tsx
@@ -1,4 +1,5 @@
 import { AccordionItem, AccordionTrigger, AccordionContent } from '@owox/ui/components/accordion';
+import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
 
 export default function ExcelDescription() {
   return (
@@ -12,6 +13,17 @@ export default function ExcelDescription() {
         <p className='mb-2'>
           Unlike other destinations, it stores no credentials: the add-in reads your data using your
           own OWOX access, and writes it into the worksheet you opened it from.
+        </p>
+        <p className='mb-2'>
+          For installation steps, including the ones for an organization where the Microsoft
+          Marketplace store is turned off, read the{' '}
+          <ExternalAnchor
+            className='underline'
+            href='https://docs.owox.com/docs/destinations/supported-destinations/microsoft-excel/?utm_source=owox_data_marts&utm_medium=destination_entity&utm_campaign=tooltip-excel'
+          >
+            OWOX documentation
+          </ExternalAnchor>
+          .
         </p>
       </AccordionContent>
     </AccordionItem>

--- a/apps/web/src/features/data-marts/reports/list/components/ReportsTable/ReportsTable.test.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/ReportsTable/ReportsTable.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DataDestinationType } from '../../../../../data-destination';
+import type { DataDestination } from '../../../../../data-destination';
+import { ReportsTable } from './ReportsTable';
+
+vi.mock('../../../shared', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../shared')>();
+  return { ...actual, useReport: () => ({ reports: [], setPollingConfig: vi.fn() }) };
+});
+
+vi.mock('../../../../../../components/AppSidebar/SetupChecklist/useSetupProgress', () => ({
+  useRefreshSetupProgress: () => vi.fn(),
+}));
+
+vi.mock('./columns', () => ({ getReportColumns: () => [] }));
+
+vi.mock('../DestinationCard/AddReportButton', () => ({
+  AddReportButton: () => (
+    <button type='button' onClick={() => undefined}>
+      New Report
+    </button>
+  ),
+}));
+
+function renderTable(type: DataDestinationType) {
+  render(
+    <ReportsTable
+      destination={{ id: 'destination-1', title: 'Microsoft Excel', type } as DataDestination}
+      onEditReport={vi.fn()}
+      onAddReport={vi.fn()}
+    />
+  );
+}
+
+describe('ReportsTable empty state', () => {
+  it('sends an Excel destination to the add-in, where its reports are made', () => {
+    renderTable(DataDestinationType.EXCEL);
+
+    const link = screen.getByRole('link', { name: /OWOX add-in in Excel/ });
+
+    // The Marketplace installation link: it opens Excel with the add-in loaded rather than
+    // explaining how to get there, which is the whole point of linking the add-in itself.
+    expect(link).toHaveAttribute(
+      'href',
+      'https://go.microsoft.com/fwlink/?linkid=2261819&templateid=WA200011946&templatetitle=OWOX%20Data%20Marts'
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.queryByRole('button', { name: 'New Report' })).not.toBeInTheDocument();
+  });
+
+  it('offers report creation, not the add-in, where this app makes the report', () => {
+    renderTable(DataDestinationType.GOOGLE_SHEETS);
+
+    expect(screen.getByRole('button', { name: 'New Report' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /OWOX add-in in Excel/ })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/reports/list/components/ReportsTable/ReportsTable.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/ReportsTable/ReportsTable.tsx
@@ -9,6 +9,23 @@ import { BaseTable } from '../../../../../../shared/components/Table';
 import { AddReportButton } from '../DestinationCard/AddReportButton';
 import { useRefreshSetupProgress } from '../../../../../../components/AppSidebar/SetupChecklist/useSetupProgress';
 import { ReportStatusEnum } from '../../../shared/enums';
+import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
+
+/**
+ * Opens Excel with the OWOX add-in loaded, installing it first for a user who does not have it.
+ * Microsoft's documented installation link for a Marketplace-published add-in: `linkid` names the
+ * Excel-on-the-web endpoint, `templateid` is the add-in's Marketplace asset ID, and `templatetitle`
+ * the name shown while it loads. Carries no UTM parameters — the redirect is Microsoft's and the
+ * destination is Excel, not a page of ours.
+ *
+ * Deliberately the add-in rather than the documentation page: an Excel report can only be created
+ * in the add-in, so this is the step that gets closest to what the empty state is asking for. It
+ * always opens Excel on the web, and it is a dead end for a tenant whose administrator disabled the
+ * Marketplace store — those users are served by the documentation link on the Excel destination's
+ * own description.
+ */
+const EXCEL_ADD_IN_URL =
+  'https://go.microsoft.com/fwlink/?linkid=2261819&templateid=WA200011946&templatetitle=OWOX%20Data%20Marts';
 
 interface ReportsTableProps {
   destination: DataDestination;
@@ -119,7 +136,10 @@ export function ReportsTable({ destination, onEditReport, onAddReport }: Reports
             </>
           ) : (
             <p className='text-muted-foreground text-sm font-medium'>
-              Create your first report from the OWOX add-in in Excel
+              Create your first report from the{' '}
+              <ExternalAnchor className='underline' href={EXCEL_ADD_IN_URL}>
+                OWOX add-in in Excel
+              </ExternalAnchor>
             </p>
           )}
         </div>


### PR DESCRIPTION
## What

A Data Mart with no Microsoft Excel reports shows

> Create your first report from the OWOX add-in in Excel

as plain text. It names the add-in but does not link it, so the empty state describes the next step without offering it. The phrase is now a link.

## Where the link goes, and why

To the **add-in**, not to the documentation page. An Excel report can only be created in the add-in, so this is the step that gets closest to what the empty state is asking for.

The target is Microsoft's documented installation link for the Marketplace listing. It opens Excel with the add-in loaded, installing it first when the user does not have it — `linkid` names the Excel-on-the-web endpoint, `templateid` is the add-in's Marketplace asset ID.

One more reason the documentation page is the wrong target here: this empty state only appears in a project that already has an Excel destination, and that destination is created by the add-in on first use. The reader does not need to be taught what the add-in is. They need to open it.

## Accepted limits

- The installation link always opens Excel **on the web**. The add-in itself still installs on every platform its manifest supports, so desktop Excel picks it up too, but the click lands in the browser.
- An organization whose administrator disabled the Marketplace store has no fallback in this surface. For them, the installation guide is now linked from the Excel destination's own description — the only destination description that was missing a documentation link.

## Not touched

`pullBasedRunHint` ("Refresh it from the OWOX add-in in Excel") stays plain text: it is the accessible name of a disabled control, and a link inside it would be unreachable by keyboard.

## Testing

- New `ReportsTable.test.tsx` covers both branches of the empty state: an Excel destination renders the add-in link with the expected `href`, `target` and `rel` and offers no create button; a Google Sheets destination offers the create button and no link.
- `npm run lint -w @owox/web` and `npm run build -w @owox/web` are clean.
- Still open: following the installation link installs the add-in into a real Microsoft account, so it has not been clicked from this branch. It needs one manual run, ideally from an account without the add-in, before release.

## Follow-up, not in this PR

The Microsoft Excel documentation page still teaches manifest sideloading and states that the add-in is not published to the store, which the live Marketplace listing contradicts. That page should lead with the Marketplace install and keep the manifest route as the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)