### PR TITLE
feat(data-marts): allow editing draft joins

### DIFF
--- a/.changeset/6905-edit-draft-joins.md
+++ b/.changeset/6905-edit-draft-joins.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Configure joins before publishing Data Marts
+
+Draft Data Mart joins can now be configured before publication, including their output fields, output aliases, and join-specific descriptions.

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
@@ -426,6 +426,14 @@ describe('DataMartController list OpenAPI', () => {
 
   it('publishes the blendable-schema response, including uniqueCountAvailability, through named component schemas', () => {
     const operation = document.paths['/api/data-marts/{id}/blendable-schema']?.get;
+    expect(operation?.parameters).toContainEqual(
+      expect.objectContaining({
+        name: 'includeDraftTargets',
+        in: 'query',
+        required: false,
+        schema: { type: 'boolean', default: false },
+      })
+    );
     expect(operation?.responses['200']).toMatchObject({
       content: {
         'application/json': {

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseBoolPipe,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Auth, AuthContext, AuthorizationContext, Role, Strategy, ViewOnlySafe } from '../../idp';
 import { BlendableSchemaDto } from '../dto/domain/blendable-schema.dto';
@@ -446,9 +457,15 @@ export class DataMartController {
   @GetBlendableSchemaSpec()
   async getBlendableSchema(
     @AuthContext() context: AuthorizationContext,
-    @Param('id') dataMartId: string
+    @Param('id') dataMartId: string,
+    @Query('includeDraftTargets', new ParseBoolPipe({ optional: true }))
+    includeDraftTargets = false
   ): Promise<BlendableSchemaDto> {
-    const command = this.mapper.toGetBlendableSchemaCommand(dataMartId, context);
+    const command = this.mapper.toGetBlendableSchemaCommand(
+      dataMartId,
+      context,
+      includeDraftTargets
+    );
     return this.getBlendableSchemaService.run(command);
   }
 }

--- a/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
@@ -353,6 +353,13 @@ export function GetBlendableSchemaSpec() {
         'Returns native fields, blended fields pulled from joined DataMarts, and the list of available sources reachable via relationships.',
     }),
     ApiParam({ name: 'id', description: 'DataMart ID' }),
+    ApiQuery({
+      name: 'includeDraftTargets',
+      required: false,
+      schema: { type: 'boolean', default: false },
+      description:
+        'Include draft relationship targets for configuration. Reporting consumers should keep the default so only published targets are returned.',
+    }),
     ApiOkResponse({ type: BlendableSchemaDto })
   );
 }

--- a/apps/backend/src/data-marts/dto/domain/get-blendable-schema.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/get-blendable-schema.command.ts
@@ -3,6 +3,7 @@ export class GetBlendableSchemaCommand {
     public readonly dataMartId: string,
     public readonly projectId: string,
     public readonly userId: string,
-    public readonly roles: string[]
+    public readonly roles: string[],
+    public readonly includeDraftTargets = false
   ) {}
 }

--- a/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
@@ -428,13 +428,15 @@ export class DataMartMapper {
 
   toGetBlendableSchemaCommand(
     dataMartId: string,
-    context: AuthorizationContext
+    context: AuthorizationContext,
+    includeDraftTargets = false
   ): GetBlendableSchemaCommand {
     return new GetBlendableSchemaCommand(
       dataMartId,
       context.projectId,
       context.userId,
-      context.roles ?? []
+      context.roles ?? [],
+      includeDraftTargets
     );
   }
 

--- a/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
@@ -188,6 +188,11 @@ describe('BlendableSchemaService', () => {
     });
 
     it('includes configured draft targets for relationship editing', async () => {
+      const draftDataMart = makeDataMart({
+        id: 'dm-b',
+        status: DataMartStatus.DRAFT,
+        schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+      });
       dataMartService.getByIdAndProjectId.mockResolvedValue(
         makeDataMart({
           id: 'dm-a',
@@ -207,10 +212,15 @@ describe('BlendableSchemaService', () => {
           id: 'rel-ab',
           targetAlias: 'b',
           sourceDataMart: makeDataMart({ id: 'dm-a' }),
+          targetDataMart: draftDataMart,
+        }),
+        makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'c',
+          sourceDataMart: draftDataMart,
           targetDataMart: makeDataMart({
-            id: 'dm-b',
-            status: DataMartStatus.DRAFT,
-            schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+            id: 'dm-c',
+            schema: makeSchema([{ name: 'c_field', type: 'INTEGER' }]),
           }),
         }),
       ]);
@@ -225,10 +235,88 @@ describe('BlendableSchemaService', () => {
           defaultAlias: 'Draft output',
           joinDescription: 'Draft join description',
           fieldCount: 1,
+          depth: 1,
+        }),
+        expect.objectContaining({
+          aliasPath: 'b.c',
+          fieldCount: 1,
+          depth: 2,
         }),
       ]);
       expect(result.blendedFields).toEqual([
         expect.objectContaining({ aliasPath: 'b', originalFieldName: 'b_field' }),
+        expect.objectContaining({ aliasPath: 'b.c', originalFieldName: 'c_field' }),
+      ]);
+    });
+
+    it('keeps calculated-field issues report-safe when draft targets are included', async () => {
+      const draftDataMart = makeDataMart({
+        id: 'dm-b',
+        status: DataMartStatus.DRAFT,
+        schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+      });
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({
+          id: 'dm-a',
+          schema: {
+            type: 'bigquery-data-mart-schema',
+            fields: [
+              {
+                name: 'mixed_total',
+                type: 'FLOAT',
+                calculated: {
+                  formula:
+                    'SUM({{ref path="b" field="b_field"}}) + SUM({{ref path="b.c" field="c_field"}}) + SUM({{ref path="d" field="d_field"}})',
+                  level: 'metric',
+                },
+              },
+            ],
+          } as unknown as DataMart['schema'],
+        })
+      );
+      relationshipService.findByStorageId.mockResolvedValue([
+        makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'b',
+          sourceDataMart: makeDataMart({ id: 'dm-a' }),
+          targetDataMart: draftDataMart,
+        }),
+        makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'c',
+          sourceDataMart: draftDataMart,
+          targetDataMart: makeDataMart({
+            id: 'dm-c',
+            schema: makeSchema([{ name: 'c_field', type: 'INTEGER' }]),
+          }),
+        }),
+        makeRelationship({
+          id: 'rel-ad',
+          targetAlias: 'd',
+          sourceDataMart: makeDataMart({ id: 'dm-a' }),
+          targetDataMart: makeDataMart({
+            id: 'dm-d',
+            schema: makeSchema([{ name: 'd_field', type: 'FLOAT' }]),
+          }),
+        }),
+      ]);
+
+      const result = await service.computeBlendableSchema('dm-a', 'project-1', defaultAccessor, {
+        includeDraftTargets: true,
+      });
+
+      expect(
+        result.blendedFields.map(({ aliasPath, originalFieldName }) => ({
+          aliasPath,
+          originalFieldName,
+        }))
+      ).toEqual([
+        { aliasPath: 'b', originalFieldName: 'b_field' },
+        { aliasPath: 'b.c', originalFieldName: 'c_field' },
+        { aliasPath: 'd', originalFieldName: 'd_field' },
+      ]);
+      expect(result.calculatedFieldIssues).toEqual([
+        { field: 'mixed_total', missing: ['b.b_field', 'b.c.c_field'] },
       ]);
     });
 

--- a/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
@@ -187,6 +187,51 @@ describe('BlendableSchemaService', () => {
       expect(result.blendedFields).toEqual([]);
     });
 
+    it('includes configured draft targets for relationship editing', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({
+          id: 'dm-a',
+          blendedFieldsConfig: {
+            sources: [
+              {
+                path: 'b',
+                alias: 'Draft output',
+                description: 'Draft join description',
+              },
+            ],
+          },
+        })
+      );
+      relationshipService.findByStorageId.mockResolvedValue([
+        makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'b',
+          sourceDataMart: makeDataMart({ id: 'dm-a' }),
+          targetDataMart: makeDataMart({
+            id: 'dm-b',
+            status: DataMartStatus.DRAFT,
+            schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+          }),
+        }),
+      ]);
+
+      const result = await service.computeBlendableSchema('dm-a', 'project-1', defaultAccessor, {
+        includeDraftTargets: true,
+      });
+
+      expect(result.availableSources).toEqual([
+        expect.objectContaining({
+          aliasPath: 'b',
+          defaultAlias: 'Draft output',
+          joinDescription: 'Draft join description',
+          fieldCount: 1,
+        }),
+      ]);
+      expect(result.blendedFields).toEqual([
+        expect.objectContaining({ aliasPath: 'b', originalFieldName: 'b_field' }),
+      ]);
+    });
+
     it('still exposes a draft root data mart, only filters draft relationship targets', async () => {
       dataMartService.getByIdAndProjectId.mockResolvedValue(
         makeDataMart({

--- a/apps/backend/src/data-marts/services/blendable-schema.service.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.ts
@@ -174,10 +174,34 @@ export class BlendableSchemaService {
 
     await this.applyReportingAccess(availableSources, projectId, accessor);
 
+    let issueSources = availableSources;
+    let issueFields = blendedFields;
+    if (options.includeDraftTargets === true) {
+      const publishedSources: AvailableSourceDto[] = [];
+      this.collectBlendedFields({
+        sourceId: dataMartId,
+        parentPath: '',
+        sourcesByPath,
+        relationshipsBySource,
+        result: [],
+        availableSources: publishedSources,
+        branchDmIds,
+        depth: 1,
+        storageType: dataMart.storage.type,
+        includeDraftTargets: false,
+      });
+      const publishedPaths = new Set(publishedSources.map(source => source.aliasPath));
+      issueSources = availableSources.filter(source => publishedPaths.has(source.aliasPath));
+      issueFields = blendedFields.filter(field => publishedPaths.has(field.aliasPath));
+    }
+
     const rawSchemaFields = dataMart.schema?.fields ?? [];
-    // The join tree this very call just walked — so a formula's joined reference is checked against
-    // the SAME tree the report builder will route it through, on the one payload the picker reads.
-    const joinedReferenceIndex = buildJoinedReferenceIndex({ availableSources, blendedFields });
+    // Draft fields may be returned for relationship editing, but formulas remain report-safe: the
+    // report builder cannot route through a draft target, so neither may this health verdict.
+    const joinedReferenceIndex = buildJoinedReferenceIndex({
+      availableSources: issueSources,
+      blendedFields: issueFields,
+    });
 
     return {
       nativeFields,

--- a/apps/backend/src/data-marts/services/blendable-schema.service.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.ts
@@ -119,6 +119,7 @@ interface CollectContext {
   branchDmIds: Set<string>;
   depth: number;
   storageType: DataStorageType;
+  includeDraftTargets: boolean;
 }
 
 @Injectable()
@@ -132,7 +133,8 @@ export class BlendableSchemaService {
   async computeBlendableSchema(
     dataMartId: string,
     projectId: string,
-    accessor: BlendableSchemaAccessor
+    accessor: BlendableSchemaAccessor,
+    options: { includeDraftTargets?: boolean } = {}
   ): Promise<BlendableSchemaDto> {
     const dataMart = await this.dataMartService.getByIdAndProjectId(dataMartId, projectId);
     const nativeFields = (dataMart.schema?.fields ?? []).filter(
@@ -167,6 +169,7 @@ export class BlendableSchemaService {
       branchDmIds,
       depth: 1,
       storageType: dataMart.storage.type,
+      includeDraftTargets: options.includeDraftTargets === true,
     });
 
     await this.applyReportingAccess(availableSources, projectId, accessor);
@@ -260,9 +263,10 @@ export class BlendableSchemaService {
         );
       }
 
-      // Reports cannot join against an unfinalized schema, so a draft target — and any
-      // descendants reachable only through it — must not surface in the picker.
-      if (rel.targetDataMart.status !== DataMartStatus.PUBLISHED) continue;
+      // Reports cannot join against an unfinalized schema. The relationship editor opts in so an
+      // analyst can configure a draft from its saved output schema before publishing it.
+      if (!ctx.includeDraftTargets && rel.targetDataMart.status !== DataMartStatus.PUBLISHED)
+        continue;
 
       if (ctx.branchDmIds.has(rel.targetDataMart.id)) continue;
 

--- a/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.spec.ts
@@ -31,7 +31,7 @@ describe('GetBlendableSchemaService', () => {
   it('returns blendable schema when user has SEE access on DataMart', async () => {
     const { service, blendableSchemaService, accessDecisionService } = createService(true);
 
-    const command = new GetBlendableSchemaCommand('dm-1', 'proj-1', 'user-1', ['viewer']);
+    const command = new GetBlendableSchemaCommand('dm-1', 'proj-1', 'user-1', ['viewer'], true);
 
     const result = await service.run(command);
 
@@ -43,10 +43,15 @@ describe('GetBlendableSchemaService', () => {
       Action.SEE,
       'proj-1'
     );
-    expect(blendableSchemaService.computeBlendableSchema).toHaveBeenCalledWith('dm-1', 'proj-1', {
-      userId: 'user-1',
-      roles: ['viewer'],
-    });
+    expect(blendableSchemaService.computeBlendableSchema).toHaveBeenCalledWith(
+      'dm-1',
+      'proj-1',
+      {
+        userId: 'user-1',
+        roles: ['viewer'],
+      },
+      { includeDraftTargets: true }
+    );
     expect(result).toBe(blendableSchema);
   });
 

--- a/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.spec.ts
@@ -55,6 +55,19 @@ describe('GetBlendableSchemaService', () => {
     expect(result).toBe(blendableSchema);
   });
 
+  it('keeps draft targets excluded by default', async () => {
+    const { service, blendableSchemaService } = createService(true);
+
+    await service.run(new GetBlendableSchemaCommand('dm-1', 'proj-1', 'user-1', ['viewer']));
+
+    expect(blendableSchemaService.computeBlendableSchema).toHaveBeenCalledWith(
+      'dm-1',
+      'proj-1',
+      { userId: 'user-1', roles: ['viewer'] },
+      { includeDraftTargets: false }
+    );
+  });
+
   it('throws ForbiddenException when user lacks SEE on DataMart', async () => {
     const { service } = createService(false);
 

--- a/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.ts
@@ -35,7 +35,8 @@ export class GetBlendableSchemaService {
     return this.blendableSchemaService.computeBlendableSchema(
       command.dataMartId,
       command.projectId,
-      { userId: command.userId, roles: command.roles }
+      { userId: command.userId, roles: command.roles },
+      { includeDraftTargets: command.includeDraftTargets }
     );
   }
 }

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.test.tsx
@@ -311,6 +311,11 @@ describe('DataMartRelationshipsContent blendable schema', () => {
     await waitFor(() => {
       expect(service.getBlendableSchema).toHaveBeenCalledTimes(1);
     });
+    expect(service.getBlendableSchema).toHaveBeenCalledWith(
+      'dm-1',
+      { includeDraftTargets: true },
+      { skipLoadingIndicator: true }
+    );
 
     await act(async () => {
       await queryClient.invalidateQueries({ queryKey: [BLENDABLE_SCHEMA_QUERY_KEY] });

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.test.tsx
@@ -301,8 +301,8 @@ describe('DataMartRelationshipsContent toolbar filters', () => {
 describe('DataMartRelationshipsContent blendable schema', () => {
   it('refetches on an invalidation of the shared key, which is what every mutation path fires', async () => {
     // This card used to refetch from an effect keyed on its relationship list; it now reads the
-    // shared query the schema editor's formula autocomplete reads too, so the refresh comes from
-    // `invalidateBlendableSchema` — the call every create/rename/delete/config-save already makes.
+    // draft-inclusive query variant, so the refresh comes from prefix invalidation — the call every
+    // create/rename/delete/config-save already makes.
     const service = vi.mocked(dataMartRelationshipService);
     // The service mock is module-level and every earlier test in this file rendered through it.
     service.getBlendableSchema.mockClear();

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
@@ -215,9 +215,12 @@ export function DataMartRelationshipsContent({
     void loadRelationships();
   }, [loadRelationships]);
 
-  // Shared with the other cards on this page (the schema editor's formula autocomplete reads the
-  // same entry): one fetch, one copy, and `invalidateBlendableSchema` below refreshes all of them.
-  const { data: blendableSchema } = useBlendableSchema(dataMartId);
+  // This editor needs draft targets so their saved output schemas and per-join overrides remain
+  // configurable before publish. The query key keeps this edit-only payload separate from the
+  // report/formula readers, while `invalidateBlendableSchema` still refreshes both variants.
+  const { data: blendableSchema } = useBlendableSchema(dataMartId, {
+    includeDraftTargets: true,
+  });
 
   const sourceList = useMemo(() => {
     if (!blendableSchema) return [];

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
@@ -230,10 +230,9 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
     reset: resetCalculatedFieldFeedback,
   } = useCalculatedFieldSave(saveSchemaMutation);
 
-  // The joined Data Marts' fields a calculated field's formula may reference. Read through the
-  // shared query, so this page holds ONE copy of the blendable schema however many of its cards
-  // need it, and a relationship change invalidated by any of them refreshes what the formula
-  // editor offers too.
+  // The joined Data Marts' fields a calculated field's formula may reference. Report-safe readers
+  // share this default query entry, and a relationship change invalidates every cached variant so
+  // the formula editor refreshes too.
   //
   // The STATUS travels with them: an empty list from a failed request must not read as "this Data
   // Mart joins nothing", or the editor refuses a correct joined reference and blames the analyst

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.test.tsx
@@ -23,6 +23,15 @@ function buildBlendedField(overrides: Partial<BlendedField> = {}): BlendedField 
   };
 }
 
+describe('SourceFieldsTable — empty states', () => {
+  it('explains that the source Data Mart has no fields', () => {
+    render(<SourceFieldsTable fields={[]} onFieldOverrideChange={() => {}} />);
+
+    expect(screen.getByText('No fields are available in the source Data Mart')).toBeInTheDocument();
+    expect(screen.queryByText('No fields match the current filter')).not.toBeInTheDocument();
+  });
+});
+
 describe('SourceFieldsTable — Post-join column', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.tsx
@@ -399,7 +399,9 @@ export function SourceFieldsTable({
                   className='text-center text-gray-400'
                   style={{ whiteSpace: 'nowrap' }}
                 >
-                  No fields match the current filter
+                  {fields.length === 0
+                    ? 'No fields are available in the source Data Mart'
+                    : 'No fields match the current filter'}
                 </TableCell>
               </TableRow>
             )}

--- a/apps/web/src/features/data-marts/shared/hooks/__tests__/useBlendableSchema.test.tsx
+++ b/apps/web/src/features/data-marts/shared/hooks/__tests__/useBlendableSchema.test.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { dataMartRelationshipService } from '../../services/data-mart-relationship.service';
+import { useBlendableSchema } from '../useBlendableSchema';
+
+vi.mock('../../services/data-mart-relationship.service', () => ({
+  dataMartRelationshipService: {
+    getBlendableSchema: vi.fn(),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useBlendableSchema', () => {
+  beforeEach(() => {
+    vi.mocked(dataMartRelationshipService.getBlendableSchema).mockReset();
+    vi.mocked(dataMartRelationshipService.getBlendableSchema).mockResolvedValue({
+      nativeFields: [],
+      blendedFields: [],
+      availableSources: [],
+    });
+  });
+
+  it('omits request params for the report-safe default', async () => {
+    renderHook(() => useBlendableSchema('dm-1'), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(dataMartRelationshipService.getBlendableSchema).toHaveBeenCalledWith(
+        'dm-1',
+        undefined,
+        { skipLoadingIndicator: true }
+      );
+    });
+  });
+
+  it('passes the draft-target opt-in', async () => {
+    renderHook(() => useBlendableSchema('dm-1', { includeDraftTargets: true }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(dataMartRelationshipService.getBlendableSchema).toHaveBeenCalledWith(
+        'dm-1',
+        { includeDraftTargets: true },
+        { skipLoadingIndicator: true }
+      );
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/shared/hooks/blendable-schema-query-key.ts
+++ b/apps/web/src/features/data-marts/shared/hooks/blendable-schema-query-key.ts
@@ -1,6 +1,6 @@
 /**
- * Shared query key for the blendable schema request.
- * Exported so that any component fetching blendable schema uses the same
- * React Query cache entry for a given data mart.
+ * Shared prefix for every blendable-schema query variant.
+ * Exported so invalidation refreshes both the default report-safe entry and
+ * option-specific entries such as the relationship editor's draft-inclusive view.
  */
 export const BLENDABLE_SCHEMA_QUERY_KEY = 'blendable-schema';

--- a/apps/web/src/features/data-marts/shared/hooks/useBlendableSchema.ts
+++ b/apps/web/src/features/data-marts/shared/hooks/useBlendableSchema.ts
@@ -6,25 +6,29 @@ import { BLENDABLE_SCHEMA_QUERY_KEY } from './blendable-schema-query-key';
 /**
  * The one way to read a Data Mart's blendable schema.
  *
- * Several parts of the Data Mart editor need it at once — the joined Data Marts card, the
- * calculated-field formula editor's joined-field autocomplete, the report column picker — and
- * they render side by side. Going through one React Query entry is what keeps them agreeing:
- * whoever asks first fetches, the rest read the same object, and the invalidation any of them
- * fires after a relationship or blended-config change refreshes all of them at once.
+ * Several parts of the Data Mart editor need it at once. Report-safe readers share the default
+ * React Query entry; options partition the key so the relationship editor's draft-inclusive
+ * payload cannot leak into report or formula inputs. Prefix invalidation still refreshes every
+ * variant after a relationship or blended-config change.
  *
  * `skipLoadingIndicator` because every caller renders its own pending state; a global overlay for
  * a request that is a detail of one card is noise.
  */
-export function useBlendableSchema(dataMartId: string) {
+export function useBlendableSchema(
+  dataMartId: string,
+  { includeDraftTargets = false }: { includeDraftTargets?: boolean } = {}
+) {
   return useQuery({
-    queryKey: [BLENDABLE_SCHEMA_QUERY_KEY, dataMartId],
+    queryKey: includeDraftTargets
+      ? [BLENDABLE_SCHEMA_QUERY_KEY, dataMartId, 'include-draft-targets']
+      : [BLENDABLE_SCHEMA_QUERY_KEY, dataMartId],
     // `getBlendableSchema` CASTS its response rather than mapping it, so the declared shape is a
     // claim about the wire, not a fact: an older or partial payload arrives with an array missing
     // and the first unguarded `for…of` takes the caller down through its error boundary.
     // Normalized once here so every reader can trust the three arrays it is typed to hold.
     queryFn: async (): Promise<BlendableSchema> => {
       const raw = (await dataMartRelationshipService
-        .getBlendableSchema(dataMartId, { skipLoadingIndicator: true })
+        .getBlendableSchema(dataMartId, { includeDraftTargets }, { skipLoadingIndicator: true })
         .catch((error: unknown) => {
           // Callers degrade quietly without it — compact ERD cards, own-Data-Mart-only formula
           // autocomplete — so leave a trace that makes those states diagnosable.

--- a/apps/web/src/features/data-marts/shared/hooks/useBlendableSchema.ts
+++ b/apps/web/src/features/data-marts/shared/hooks/useBlendableSchema.ts
@@ -8,8 +8,9 @@ import { BLENDABLE_SCHEMA_QUERY_KEY } from './blendable-schema-query-key';
  *
  * Several parts of the Data Mart editor need it at once. Report-safe readers share the default
  * React Query entry; options partition the key so the relationship editor's draft-inclusive
- * payload cannot leak into report or formula inputs. Prefix invalidation still refreshes every
- * variant after a relationship or blended-config change.
+ * payload cannot leak into report or formula inputs. When both variants render on one page, this
+ * intentionally means two requests. Prefix invalidation still refreshes every variant after a
+ * relationship or blended-config change.
  *
  * `skipLoadingIndicator` because every caller renders its own pending state; a global overlay for
  * a request that is a detail of one card is noise.
@@ -28,7 +29,11 @@ export function useBlendableSchema(
     // Normalized once here so every reader can trust the three arrays it is typed to hold.
     queryFn: async (): Promise<BlendableSchema> => {
       const raw = (await dataMartRelationshipService
-        .getBlendableSchema(dataMartId, { includeDraftTargets }, { skipLoadingIndicator: true })
+        .getBlendableSchema(
+          dataMartId,
+          includeDraftTargets ? { includeDraftTargets: true } : undefined,
+          { skipLoadingIndicator: true }
+        )
         .catch((error: unknown) => {
           // Callers degrade quietly without it — compact ERD cards, own-Data-Mart-only formula
           // autocomplete — so leave a trace that makes those states diagnosable.

--- a/apps/web/src/features/data-marts/shared/hooks/useInvalidateBlendableSchema.ts
+++ b/apps/web/src/features/data-marts/shared/hooks/useInvalidateBlendableSchema.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { BLENDABLE_SCHEMA_QUERY_KEY } from './blendable-schema-query-key';
 
 /**
- * Refetches the blendable schema every reader on the page shares.
+ * Refetches every cached blendable-schema variant used by readers on the page.
  *
  * A Data Mart's schema decides what that payload holds — its native fields, and the backend's
  * verdict on which calculated fields still resolve — so whoever persists a schema has to

--- a/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
@@ -80,13 +80,15 @@ class DataMartRelationshipService extends ApiService {
   /**
    * Get the blendable schema for a data mart.
    * @param dataMartId Data mart ID
+   * @param params Optional view controls; draft targets are excluded by default.
    * @param config Optional axios config (e.g. `skipLoadingIndicator` for silent refreshes)
    */
   async getBlendableSchema(
     dataMartId: string,
+    params?: { includeDraftTargets?: boolean },
     config?: AxiosRequestConfig
   ): Promise<BlendableSchema> {
-    return this.get<BlendableSchema>(`/${dataMartId}/blendable-schema`, undefined, config);
+    return this.get<BlendableSchema>(`/${dataMartId}/blendable-schema`, params, config);
   }
 
   /**


### PR DESCRIPTION
## Summary

- allow the relationship editor to include configured draft Data Mart targets
- expose draft output fields, aliases, and join-specific descriptions before publication
- keep report, formula, and runtime consumers on the published-only default
- add a release changeset for Fibery work item 6905

## Testing

- `npm test -w @owox/backend -- --runInBand`
- `npm test -w @owox/web`
- `npm run build -w @owox/backend`
- `npm run build -w @owox/web`
- `npm run lint -w @owox/backend`
- `npm run lint -w @owox/web`
- `npm exec -- prettier --check <changed files>`
- `git diff --check`

## Notes

The default parallel backend test run hit the existing wall-clock threshold in `formula-analyzer.spec.ts` under CPU contention. The test passed in isolation, and the full backend suite passed serially (613 suites, 9435 tests).
