### PR TITLE
fix(data-marts): keep output schema field connection statuses server-owned

### DIFF
--- a/.changeset/6935-output-schema-field-connection-status.md
+++ b/.changeset/6935-output-schema-field-connection-status.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Keep output schema field connection statuses server-controlled
+
+Output schema updates no longer accept a client-provided connection status as the field's actual state. API users and plugin developers could previously encounter misleading connected fields when saving a schema before the storage had verified them; the backend now derives the status, and the web app omits it from update requests.

--- a/apps/backend/src/data-marts/data-storage-types/data-mart-schema.type.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-mart-schema.type.ts
@@ -16,22 +16,4 @@ export const DataMartSchemaSchema = z.discriminatedUnion('type', [
 export type DataMartSchema = z.infer<typeof DataMartSchemaSchema>;
 export type DataMartSchemaField = DataMartSchema['fields'][number];
 
-type KnownKey<Key> = string extends Key
-  ? never
-  : number extends Key
-    ? never
-    : symbol extends Key
-      ? never
-      : Key;
-
-type WithoutConnectionStatus<T> = T extends readonly unknown[]
-  ? { [Index in keyof T]: WithoutConnectionStatus<T[Index]> }
-  : T extends object
-    ? {
-        [Key in keyof T as Key extends 'status' ? never : KnownKey<Key>]: WithoutConnectionStatus<
-          T[Key]
-        >;
-      }
-    : T;
-
-export type DataMartSchemaUpdate = WithoutConnectionStatus<z.input<typeof DataMartSchemaSchema>>;
+export type DataMartSchemaUpdate = z.input<typeof DataMartSchemaSchema>;

--- a/apps/backend/src/data-marts/data-storage-types/data-mart-schema.type.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-mart-schema.type.ts
@@ -15,3 +15,23 @@ export const DataMartSchemaSchema = z.discriminatedUnion('type', [
 
 export type DataMartSchema = z.infer<typeof DataMartSchemaSchema>;
 export type DataMartSchemaField = DataMartSchema['fields'][number];
+
+type KnownKey<Key> = string extends Key
+  ? never
+  : number extends Key
+    ? never
+    : symbol extends Key
+      ? never
+      : Key;
+
+type WithoutConnectionStatus<T> = T extends readonly unknown[]
+  ? { [Index in keyof T]: WithoutConnectionStatus<T[Index]> }
+  : T extends object
+    ? {
+        [Key in keyof T as Key extends 'status' ? never : KnownKey<Key>]: WithoutConnectionStatus<
+          T[Key]
+        >;
+      }
+    : T;
+
+export type DataMartSchemaUpdate = WithoutConnectionStatus<z.input<typeof DataMartSchemaSchema>>;

--- a/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.ts
@@ -300,7 +300,10 @@ export function createBaseFieldSchemaForType<T extends z.ZodTypeAny>(schemaField
         .describe('Formula definition; present only on calculated fields'),
       status: z
         .nativeEnum(DataMartSchemaFieldStatus)
-        .describe('Field status relatively to the actual data mart schema'),
+        .default(DataMartSchemaFieldStatus.DISCONNECTED)
+        .describe(
+          'Server-owned field status relative to the actual data mart schema; ignored on updates'
+        ),
     })
     // ROLLING-DEPLOY SAFETY, and it is about data loss rather than validation. This schema is a
     // TypeORM value transformer: `createZodTransformer.from` parses it on every entity LOAD, and a

--- a/apps/backend/src/data-marts/dto/domain/update-data-mart-schema.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-data-mart-schema.command.ts
@@ -1,10 +1,10 @@
-import { DataMartSchema } from '../../data-storage-types/data-mart-schema.type';
+import type { DataMartSchemaUpdate } from '../../data-storage-types/data-mart-schema.type';
 
 export class UpdateDataMartSchemaCommand {
   constructor(
     public readonly id: string,
     public readonly projectId: string,
-    public readonly schema: DataMartSchema,
+    public readonly schema: DataMartSchemaUpdate,
     public readonly userId: string = '',
     public readonly roles: string[] = []
   ) {}

--- a/apps/backend/src/data-marts/dto/presentation/update-data-mart-schema-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-data-mart-schema-api.dto.ts
@@ -8,7 +8,7 @@ export class UpdateDataMartSchemaApiDto {
     type: () => Object,
     required: true,
     description:
-      'Updated schema of the data mart. Field connection statuses are server-owned: omit them, and any value sent by an older client is ignored. The saved schema carries the last status the server derived; a new native field starts DISCONNECTED until schema actualization (POST /data-marts/{id}/schema-actualize-triggers) verifies it against the storage.',
+      'Updated schema of the data mart. Field connection statuses are server-owned: omit them, and any value sent by an older client is ignored. The saved schema carries the last status the server derived; a new native field starts DISCONNECTED until schema actualization (POST /api/data-marts/{dataMartId}/schema-actualize-triggers) verifies it against the storage.',
   })
   @IsNotEmptyObject()
   schema: DataMartSchemaUpdate;

--- a/apps/backend/src/data-marts/dto/presentation/update-data-mart-schema-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-data-mart-schema-api.dto.ts
@@ -1,16 +1,17 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmptyObject } from 'class-validator';
-import { DataMartSchema } from '../../data-storage-types/data-mart-schema.type';
+import type { DataMartSchemaUpdate } from '../../data-storage-types/data-mart-schema.type';
 import { DataMartResponseApiDto } from './data-mart-response-api.dto';
 
 export class UpdateDataMartSchemaApiDto {
   @ApiProperty({
     type: () => Object,
     required: true,
-    description: 'Updated schema of the data mart',
+    description:
+      'Updated schema of the data mart. Field connection statuses are server-owned: omit them, and any value sent by an older client is ignored. The saved schema carries the last status the server derived; a new native field starts DISCONNECTED until schema actualization (POST /data-marts/{id}/schema-actualize-triggers) verifies it against the storage.',
   })
   @IsNotEmptyObject()
-  schema: DataMartSchema;
+  schema: DataMartSchemaUpdate;
 }
 
 export class FormulaViolationApiDto {

--- a/apps/backend/src/data-marts/dto/presentation/update-data-mart-schema-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-data-mart-schema-api.dto.ts
@@ -8,7 +8,7 @@ export class UpdateDataMartSchemaApiDto {
     type: () => Object,
     required: true,
     description:
-      'Updated schema of the data mart. Field connection statuses are server-owned: omit them, and any value sent by an older client is ignored. The saved schema carries the last status the server derived; a new native field starts DISCONNECTED until schema actualization (POST /api/data-marts/{dataMartId}/schema-actualize-triggers) verifies it against the storage.',
+      'Updated schema of the data mart. Field connection statuses are server-owned: omit them, and any value sent by an older client is ignored. The saved schema carries the last status derived by schema actualization; a new native field starts DISCONNECTED until schema actualization (POST /api/data-marts/{dataMartId}/schema-actualize-triggers) verifies it against the storage, and a formula may only reference native fields that are already connected.',
   })
   @IsNotEmptyObject()
   schema: DataMartSchemaUpdate;

--- a/apps/backend/src/data-marts/entities/data-mart.entity.ts
+++ b/apps/backend/src/data-marts/entities/data-mart.entity.ts
@@ -57,7 +57,7 @@ export class DataMart implements CreatorAwareEntity {
   schema?: DataMartSchema;
 
   @Column({ type: 'datetime', nullable: true })
-  schemaActualizedAt?: Date;
+  schemaActualizedAt?: Date | null;
 
   @Column({ type: 'varchar', nullable: true })
   definitionType?: DataMartDefinitionType | null;

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-schema.service.spec.ts
@@ -136,9 +136,26 @@ describe('UpdateDataMartSchemaService', () => {
     });
 
     it('derives statuses for new native and calculated fields', async () => {
+      const persistedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'account_id',
+            type: 'STRING',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+          },
+        ],
+      };
       const submittedSchema = {
         type: 'bigquery-data-mart-schema',
         fields: [
+          {
+            name: 'account_id',
+            type: 'STRING',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+          },
           {
             name: 'manual_field',
             type: 'STRING',
@@ -150,16 +167,23 @@ describe('UpdateDataMartSchemaService', () => {
             type: 'STRING',
             mode: 'NULLABLE',
             status: DataMartSchemaFieldStatus.DISCONNECTED,
-            calculated: { formula: 'UPPER({{ref field="manual_field"}})', level: 'column' },
+            calculated: { formula: 'UPPER({{ref field="account_id"}})', level: 'column' },
           },
         ],
       };
+      const dataMart = {
+        id: 'target-1',
+        projectId: 'project-1',
+        storage: { type: DataStorageType.GOOGLE_BIGQUERY },
+        schema: persistedSchema,
+      };
       const validate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
-      const { service } = buildService({ validate, parsedSchema: submittedSchema });
+      const { service } = buildService({ validate, parsedSchema: submittedSchema, dataMart });
 
       await service.run(new UpdateDataMartSchemaCommand('target-1', 'project-1', {} as never));
 
       expect(submittedSchema.fields.map(field => field.status)).toEqual([
+        DataMartSchemaFieldStatus.CONNECTED,
         DataMartSchemaFieldStatus.DISCONNECTED,
         DataMartSchemaFieldStatus.CONNECTED,
       ]);
@@ -264,6 +288,149 @@ describe('UpdateDataMartSchemaService', () => {
       await service.run(new UpdateDataMartSchemaCommand('target-1', 'project-1', {} as never));
 
       expect(submittedSchema.fields[0].status).toBe(DataMartSchemaFieldStatus.DISCONNECTED);
+    });
+
+    it('clears schemaActualizedAt when the save introduces a native field, nested included', async () => {
+      const persistedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'event',
+            type: 'RECORD',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+            fields: [
+              {
+                name: 'params',
+                type: 'STRING',
+                mode: 'NULLABLE',
+                status: DataMartSchemaFieldStatus.CONNECTED,
+              },
+            ],
+          },
+        ],
+      };
+      const submittedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'event',
+            type: 'RECORD',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+            fields: [
+              {
+                name: 'params',
+                type: 'STRING',
+                mode: 'NULLABLE',
+                status: DataMartSchemaFieldStatus.CONNECTED,
+              },
+              {
+                name: 'added_later',
+                type: 'STRING',
+                mode: 'NULLABLE',
+                status: DataMartSchemaFieldStatus.CONNECTED,
+              },
+            ],
+          },
+        ],
+      };
+      const dataMart = {
+        id: 'target-1',
+        projectId: 'project-1',
+        storage: { type: DataStorageType.GOOGLE_BIGQUERY },
+        schema: persistedSchema,
+        schemaActualizedAt: new Date('2026-09-10T10:00:00Z'),
+      };
+      const validate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
+      const { service } = buildService({ validate, parsedSchema: submittedSchema, dataMart });
+
+      await service.run(new UpdateDataMartSchemaCommand('target-1', 'project-1', {} as never));
+
+      expect(dataMart.schemaActualizedAt).toBeNull();
+    });
+
+    it('keeps schemaActualizedAt when every native field has a persisted namesake', async () => {
+      const actualizedAt = new Date('2026-09-10T10:00:00Z');
+      const persistedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'account_id',
+            type: 'STRING',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+          },
+        ],
+      };
+      const submittedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'account_id',
+            type: 'STRING',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+          },
+          {
+            name: 'account_label',
+            type: 'STRING',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.DISCONNECTED,
+            calculated: { formula: 'UPPER({{ref field="account_id"}})', level: 'column' },
+          },
+        ],
+      };
+      const dataMart = {
+        id: 'target-1',
+        projectId: 'project-1',
+        storage: { type: DataStorageType.GOOGLE_BIGQUERY },
+        schema: persistedSchema,
+        schemaActualizedAt: actualizedAt,
+      };
+      const validate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
+      const { service } = buildService({ validate, parsedSchema: submittedSchema, dataMart });
+
+      await service.run(new UpdateDataMartSchemaCommand('target-1', 'project-1', {} as never));
+
+      expect(dataMart.schemaActualizedAt).toBe(actualizedAt);
+    });
+
+    it('tolerates a non-array nested fields value on a flat-storage field', async () => {
+      const persistedSchema = {
+        type: 'athena-data-mart-schema',
+        fields: [
+          {
+            name: 'payload',
+            type: 'string',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+            fields: {},
+          },
+        ],
+      };
+      const submittedSchema = {
+        type: 'athena-data-mart-schema',
+        fields: [
+          {
+            name: 'payload',
+            type: 'string',
+            status: DataMartSchemaFieldStatus.DISCONNECTED,
+            fields: {},
+          },
+        ],
+      };
+      const dataMart = {
+        id: 'target-1',
+        projectId: 'project-1',
+        storage: { type: DataStorageType.AWS_ATHENA },
+        schema: persistedSchema,
+      };
+      const validate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
+      const { service } = buildService({ validate, parsedSchema: submittedSchema, dataMart });
+
+      await service.run(new UpdateDataMartSchemaCommand('target-1', 'project-1', {} as never));
+
+      expect(submittedSchema.fields[0].status).toBe(DataMartSchemaFieldStatus.CONNECTED);
     });
   });
 

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-schema.service.spec.ts
@@ -4,6 +4,7 @@ jest.mock('typeorm-transactional', () => ({
 }));
 
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+import { DataMartSchemaFieldStatus } from '../data-storage-types/enums/data-mart-schema-field-status.enum';
 import { UpdateDataMartSchemaCommand } from '../dto/domain/update-data-mart-schema.command';
 import { UpdateDataMartSchemaService } from './update-data-mart-schema.service';
 
@@ -92,6 +93,178 @@ describe('UpdateDataMartSchemaService', () => {
       'target-1',
       'project-1'
     );
+  });
+
+  describe('field connection status', () => {
+    it('keeps the persisted status for an existing native field', async () => {
+      const persistedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'account_id',
+            type: 'STRING',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED_WITH_DEFINITION_MISMATCH,
+          },
+        ],
+      };
+      const submittedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'account_id',
+            type: 'STRING',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+          },
+        ],
+      };
+      const dataMart = {
+        id: 'target-1',
+        projectId: 'project-1',
+        storage: { type: DataStorageType.GOOGLE_BIGQUERY },
+        schema: persistedSchema,
+      };
+      const validate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
+      const { service } = buildService({ validate, parsedSchema: submittedSchema, dataMart });
+
+      await service.run(new UpdateDataMartSchemaCommand('target-1', 'project-1', {} as never));
+
+      expect(submittedSchema.fields[0].status).toBe(
+        DataMartSchemaFieldStatus.CONNECTED_WITH_DEFINITION_MISMATCH
+      );
+    });
+
+    it('derives statuses for new native and calculated fields', async () => {
+      const submittedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'manual_field',
+            type: 'STRING',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+          },
+          {
+            name: 'calculated_field',
+            type: 'STRING',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.DISCONNECTED,
+            calculated: { formula: 'UPPER({{ref field="manual_field"}})', level: 'column' },
+          },
+        ],
+      };
+      const validate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
+      const { service } = buildService({ validate, parsedSchema: submittedSchema });
+
+      await service.run(new UpdateDataMartSchemaCommand('target-1', 'project-1', {} as never));
+
+      expect(submittedSchema.fields.map(field => field.status)).toEqual([
+        DataMartSchemaFieldStatus.DISCONNECTED,
+        DataMartSchemaFieldStatus.CONNECTED,
+      ]);
+    });
+
+    it('keeps persisted statuses of nested fields by name', async () => {
+      const persistedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'event',
+            type: 'RECORD',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+            fields: [
+              {
+                name: 'params',
+                type: 'STRING',
+                mode: 'NULLABLE',
+                status: DataMartSchemaFieldStatus.CONNECTED_WITH_DEFINITION_MISMATCH,
+              },
+            ],
+          },
+        ],
+      };
+      const submittedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'event',
+            type: 'RECORD',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.DISCONNECTED,
+            fields: [
+              {
+                name: 'params',
+                type: 'STRING',
+                mode: 'NULLABLE',
+                status: DataMartSchemaFieldStatus.CONNECTED,
+              },
+              {
+                name: 'added_later',
+                type: 'STRING',
+                mode: 'NULLABLE',
+                status: DataMartSchemaFieldStatus.CONNECTED,
+              },
+            ],
+          },
+        ],
+      };
+      const dataMart = {
+        id: 'target-1',
+        projectId: 'project-1',
+        storage: { type: DataStorageType.GOOGLE_BIGQUERY },
+        schema: persistedSchema,
+      };
+      const validate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
+      const { service } = buildService({ validate, parsedSchema: submittedSchema, dataMart });
+
+      await service.run(new UpdateDataMartSchemaCommand('target-1', 'project-1', {} as never));
+
+      expect(submittedSchema.fields[0].status).toBe(DataMartSchemaFieldStatus.CONNECTED);
+      expect(submittedSchema.fields[0].fields.map(field => field.status)).toEqual([
+        DataMartSchemaFieldStatus.CONNECTED_WITH_DEFINITION_MISMATCH,
+        DataMartSchemaFieldStatus.DISCONNECTED,
+      ]);
+    });
+
+    it('does not inherit a status from a persisted calculated field of the same name', async () => {
+      const persistedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'revenue',
+            type: 'NUMERIC',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+            calculated: { formula: 'SUM({{ref field="amount"}})', level: 'metric' },
+          },
+        ],
+      };
+      const submittedSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'revenue',
+            type: 'NUMERIC',
+            mode: 'NULLABLE',
+            status: DataMartSchemaFieldStatus.CONNECTED,
+          },
+        ],
+      };
+      const dataMart = {
+        id: 'target-1',
+        projectId: 'project-1',
+        storage: { type: DataStorageType.GOOGLE_BIGQUERY },
+        schema: persistedSchema,
+      };
+      const validate = jest.fn().mockResolvedValue({ errors: [], warnings: [] });
+      const { service } = buildService({ validate, parsedSchema: submittedSchema, dataMart });
+
+      await service.run(new UpdateDataMartSchemaCommand('target-1', 'project-1', {} as never));
+
+      expect(submittedSchema.fields[0].status).toBe(DataMartSchemaFieldStatus.DISCONNECTED);
+    });
   });
 
   // A cached Looker Studio reader is keyed on `report.id` + `expiresAt` alone — nothing in the key

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-schema.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-schema.service.ts
@@ -2,13 +2,18 @@ import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { DataMart } from '../entities/data-mart.entity';
-import { calculatedFieldsOf } from '../calculated-fields/calculated-field.utils';
+import { calculatedFieldsOf, isCalculatedField } from '../calculated-fields/calculated-field.utils';
 import {
   CalculatedFieldValidatorService,
   DryRunContext,
 } from '../calculated-fields/calculated-field-validator.service';
 import { FormulaViolations } from '../calculated-fields/formula-violations';
 import { DataStorageCredentialsResolver } from '../data-storage-types/data-storage-credentials-resolver.service';
+import type {
+  DataMartSchema,
+  DataMartSchemaField,
+} from '../data-storage-types/data-mart-schema.type';
+import { DataMartSchemaFieldStatus } from '../data-storage-types/enums/data-mart-schema-field-status.enum';
 import { DataMartSchemaParserFacade } from '../data-storage-types/facades/data-mart-schema-parser-facade.service';
 import { UpdateDataMartSchemaCommand } from '../dto/domain/update-data-mart-schema.command';
 import { UpdateDataMartSchemaResult } from '../dto/domain/update-data-mart-schema-result.dto';
@@ -55,6 +60,7 @@ export class UpdateDataMartSchemaService {
       command.schema,
       dataMart.storage.type
     );
+    applyServerOwnedFieldStatuses(parsed, dataMart.schema);
 
     // Assigned BEFORE the dry run, not after: composeMetricsOnly (via CalculatedFieldValidatorService)
     // reads `ctx.dataMart.schema` to find each metric's formula, so the context below must carry
@@ -168,5 +174,39 @@ export class UpdateDataMartSchemaService {
   private async saveAndInvalidate(dataMart: DataMart): Promise<void> {
     await this.dataMartService.save(dataMart);
     await this.reportDataCacheService.invalidateByDataMartId(dataMart.id);
+  }
+}
+
+function applyServerOwnedFieldStatuses(
+  schema: DataMartSchema,
+  persistedSchema: DataMartSchema | undefined
+): void {
+  // Connection status is derived by schema actualization. A manual API save may only carry the
+  // last server-owned value forward; a new warehouse field starts disconnected.
+  const persistedFields = persistedSchema?.type === schema.type ? persistedSchema.fields : [];
+  applyFieldStatuses(schema.fields, persistedFields);
+}
+
+function applyFieldStatuses(
+  fields: DataMartSchemaField[],
+  persistedFields: readonly DataMartSchemaField[]
+): void {
+  const persistedByName = new Map(persistedFields.map(field => [field.name, field]));
+
+  for (const field of fields) {
+    const persistedField = persistedByName.get(field.name);
+    field.status = isCalculatedField(field)
+      ? DataMartSchemaFieldStatus.CONNECTED
+      : persistedField && !isCalculatedField(persistedField)
+        ? persistedField.status
+        : DataMartSchemaFieldStatus.DISCONNECTED;
+
+    if ('fields' in field && field.fields) {
+      const persistedNestedFields =
+        persistedField && 'fields' in persistedField && persistedField.fields
+          ? persistedField.fields
+          : [];
+      applyFieldStatuses(field.fields, persistedNestedFields);
+    }
   }
 }

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-schema.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-schema.service.ts
@@ -60,7 +60,7 @@ export class UpdateDataMartSchemaService {
       command.schema,
       dataMart.storage.type
     );
-    applyServerOwnedFieldStatuses(parsed, dataMart.schema);
+    const introducesNativeField = applyServerOwnedFieldStatuses(parsed, dataMart.schema);
 
     // Assigned BEFORE the dry run, not after: composeMetricsOnly (via CalculatedFieldValidatorService)
     // reads `ctx.dataMart.schema` to find each metric's formula, so the context below must carry
@@ -70,6 +70,10 @@ export class UpdateDataMartSchemaService {
     // assign here: `dataMart` stays unsaved until `dataMartService.save` below, so a validation
     // failure afterwards just leaves the in-memory mutation unpersisted.
     dataMart.schema = parsed;
+    if (introducesNativeField) {
+      // Read as expired by actualizeSchemaIfExpired, so lazy readers re-check the warehouse.
+      dataMart.schemaActualizedAt = null;
+    }
 
     const calculatedFields = calculatedFieldsOf(parsed.fields);
     const storageConfig = dataMart.storage.config;
@@ -180,33 +184,41 @@ export class UpdateDataMartSchemaService {
 function applyServerOwnedFieldStatuses(
   schema: DataMartSchema,
   persistedSchema: DataMartSchema | undefined
-): void {
+): boolean {
   // Connection status is derived by schema actualization. A manual API save may only carry the
   // last server-owned value forward; a new warehouse field starts disconnected.
   const persistedFields = persistedSchema?.type === schema.type ? persistedSchema.fields : [];
-  applyFieldStatuses(schema.fields, persistedFields);
+  return applyFieldStatuses(schema.fields, persistedFields);
 }
 
 function applyFieldStatuses(
   fields: DataMartSchemaField[],
   persistedFields: readonly DataMartSchemaField[]
-): void {
+): boolean {
   const persistedByName = new Map(persistedFields.map(field => [field.name, field]));
+  let introducesNativeField = false;
 
   for (const field of fields) {
     const persistedField = persistedByName.get(field.name);
-    field.status = isCalculatedField(field)
-      ? DataMartSchemaFieldStatus.CONNECTED
-      : persistedField && !isCalculatedField(persistedField)
-        ? persistedField.status
-        : DataMartSchemaFieldStatus.DISCONNECTED;
+    if (isCalculatedField(field)) {
+      field.status = DataMartSchemaFieldStatus.CONNECTED;
+    } else if (persistedField && !isCalculatedField(persistedField)) {
+      field.status = persistedField.status;
+    } else {
+      field.status = DataMartSchemaFieldStatus.DISCONNECTED;
+      introducesNativeField = true;
+    }
 
-    if ('fields' in field && field.fields) {
-      const persistedNestedFields =
-        persistedField && 'fields' in persistedField && persistedField.fields
-          ? persistedField.fields
-          : [];
-      applyFieldStatuses(field.fields, persistedNestedFields);
+    const nestedFields = nestedFieldsOf(field);
+    if (nestedFields) {
+      const persistedNestedFields = persistedField ? (nestedFieldsOf(persistedField) ?? []) : [];
+      introducesNativeField =
+        applyFieldStatuses(nestedFields, persistedNestedFields) || introducesNativeField;
     }
   }
+  return introducesNativeField;
+}
+
+function nestedFieldsOf(field: DataMartSchemaField): DataMartSchemaField[] | undefined {
+  return 'fields' in field && Array.isArray(field.fields) ? field.fields : undefined;
 }

--- a/apps/backend/test/blended-output-controls.e2e-spec.ts
+++ b/apps/backend/test/blended-output-controls.e2e-spec.ts
@@ -48,7 +48,7 @@ describe('Blended output controls full-flow (e2e)', () => {
     ]);
     app = testApp.app;
     agent = testApp.agent;
-    prereqs = await setupBlendedReportPrerequisites(agent, { withSchemas: true });
+    prereqs = await setupBlendedReportPrerequisites(agent, { withSchemas: true, app });
   }, 60_000);
 
   afterAll(async () => {

--- a/apps/backend/test/formula-live-validation.e2e-spec.ts
+++ b/apps/backend/test/formula-live-validation.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
   closeTestApp,
   setupReportPrerequisites,
   AUTH_HEADER,
+  setDataMartSchema,
 } from '@owox/test-utils';
 import { SqlDryRunExecutorFacade } from 'src/data-marts/data-storage-types/facades/sql-dry-run-executor.facade';
 import { IdpProjectionsFacade } from '../src/idp/facades/idp-projections.facade';
@@ -92,32 +93,25 @@ describe('Formula live validation API (e2e)', () => {
     const prereqs = await setupReportPrerequisites(agent);
     dataMartId = prereqs.dataMartId;
 
-    const schemaRes = await agent
-      .put(`/api/data-marts/${dataMartId}/schema`)
-      .set(AUTH_HEADER)
-      .send({
-        schema: {
-          type: 'bigquery-data-mart-schema',
-          fields: [
-            { name: 'clicks', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
-            { name: 'impressions', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
-            // A metric that already exists, so a request can be shown breaking something other
-            // than the field it names.
-            {
-              name: 'roas',
-              type: 'FLOAT',
-              mode: 'NULLABLE',
-              status: 'CONNECTED',
-              calculated: {
-                formula:
-                  'SUM({{ref field="clicks"}}) / NULLIF(SUM({{ref field="impressions"}}), 0)',
-                level: 'metric',
-              },
-            },
-          ],
+    await setDataMartSchema(agent, app, dataMartId, {
+      type: 'bigquery-data-mart-schema',
+      fields: [
+        { name: 'clicks', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
+        { name: 'impressions', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
+        // A metric that already exists, so a request can be shown breaking something other
+        // than the field it names.
+        {
+          name: 'roas',
+          type: 'FLOAT',
+          mode: 'NULLABLE',
+          status: 'CONNECTED',
+          calculated: {
+            formula: 'SUM({{ref field="clicks"}}) / NULLIF(SUM({{ref field="impressions"}}), 0)',
+            level: 'metric',
+          },
         },
-      });
-    expect(schemaRes.status).toBe(200);
+      ],
+    });
   }, 120_000);
 
   afterAll(async () => {

--- a/apps/backend/test/http-data.e2e-spec.ts
+++ b/apps/backend/test/http-data.e2e-spec.ts
@@ -9,6 +9,7 @@ import {
   setupPublishedDataMart,
   setupReportPrerequisites,
   ReportBuilder,
+  setDataMartSchema,
 } from '@owox/test-utils';
 import { TypeResolver } from '../src/common/resolver/type-resolver';
 import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../src/data-marts/data-storage-types/data-storage-providers';
@@ -910,27 +911,21 @@ describe('HTTP Data API (e2e)', () => {
       const prereqs = await setupPublishedDataMart(agent);
       dataMartWithCtrId = prereqs.dataMartId;
 
-      const schemaRes = await agent
-        .put(`/api/data-marts/${dataMartWithCtrId}/schema`)
-        .set(AUTH_HEADER)
-        .send({
-          schema: {
-            type: 'bigquery-data-mart-schema',
-            fields: [
-              { name: 'country', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
-              { name: 'clicks', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
-              { name: 'impressions', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
-              {
-                name: 'ctr',
-                type: 'FLOAT',
-                mode: 'NULLABLE',
-                status: 'CONNECTED',
-                calculated: { formula: CTR_FORMULA, level: 'metric' },
-              },
-            ],
+      await setDataMartSchema(agent, app, dataMartWithCtrId, {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          { name: 'country', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+          { name: 'clicks', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
+          { name: 'impressions', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
+          {
+            name: 'ctr',
+            type: 'FLOAT',
+            mode: 'NULLABLE',
+            status: 'CONNECTED',
+            calculated: { formula: CTR_FORMULA, level: 'metric' },
           },
-        });
-      expect(schemaRes.status).toBe(200);
+        ],
+      });
 
       // HttpDataColumnResolver / HttpDataColumnValidator / OutputControlsValidatorService all
       // read through the mocked BlendableSchemaService, never the persisted schema directly (that

--- a/apps/backend/test/output-controls-databricks-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-databricks-emission.e2e-spec.ts
@@ -12,6 +12,7 @@ import {
   signLookerPayload,
   mockGoogleJwkFetch,
   restoreGoogleJwkFetch,
+  setDataMartSchema,
 } from '@owox/test-utils';
 import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
 import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
@@ -114,19 +115,14 @@ describe('Output controls — Databricks SQL emission (e2e)', () => {
       .set(AUTH_HEADER)
       .send({ definitionType: 'TABLE', definition: { fullyQualifiedName: 'cat.sch.events' } });
 
-    await agent
-      .put(`/api/data-marts/${dataMartId}/schema`)
-      .set(AUTH_HEADER)
-      .send({
-        schema: {
-          type: 'databricks-data-mart-schema',
-          table: 'cat.sch.events',
-          fields: [
-            { name: 'id', type: 'INT', status: 'CONNECTED', isPrimaryKey: false },
-            { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
-          ],
-        },
-      });
+    await setDataMartSchema(agent, app, dataMartId, {
+      type: 'databricks-data-mart-schema',
+      table: 'cat.sch.events',
+      fields: [
+        { name: 'id', type: 'INT', status: 'CONNECTED', isPrimaryKey: false },
+        { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
+      ],
+    });
 
     expect((await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER)).status).toBe(
       200

--- a/apps/backend/test/output-controls-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-emission.e2e-spec.ts
@@ -12,6 +12,7 @@ import {
   signLookerPayload,
   mockGoogleJwkFetch,
   restoreGoogleJwkFetch,
+  setDataMartSchema,
 } from '@owox/test-utils';
 import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
 import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
@@ -112,18 +113,13 @@ describe('Output controls — Athena SQL emission (e2e)', () => {
       .set(AUTH_HEADER)
       .send({ definitionType: 'TABLE', definition: { fullyQualifiedName: 'testdb.events' } });
 
-    await agent
-      .put(`/api/data-marts/${dataMartId}/schema`)
-      .set(AUTH_HEADER)
-      .send({
-        schema: {
-          type: 'athena-data-mart-schema',
-          fields: [
-            { name: 'id', type: 'INTEGER', status: 'CONNECTED', isPrimaryKey: false },
-            { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
-          ],
-        },
-      });
+    await setDataMartSchema(agent, app, dataMartId, {
+      type: 'athena-data-mart-schema',
+      fields: [
+        { name: 'id', type: 'INTEGER', status: 'CONNECTED', isPrimaryKey: false },
+        { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
+      ],
+    });
 
     expect((await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER)).status).toBe(
       200

--- a/apps/backend/test/output-controls-legacy-bq-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-legacy-bq-emission.e2e-spec.ts
@@ -11,6 +11,7 @@ import {
   signLookerPayload,
   mockGoogleJwkFetch,
   restoreGoogleJwkFetch,
+  setDataMartSchema,
 } from '@owox/test-utils';
 import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
 import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
@@ -160,30 +161,19 @@ describe('Output controls — Legacy BigQuery SQL emission (e2e)', () => {
         definition: { sqlQuery: 'SELECT id, created_at FROM events' },
       });
 
-    await agent
-      .put(`/api/data-marts/${dataMartId}/schema`)
-      .set(AUTH_HEADER)
-      .send({
-        schema: {
-          type: 'bigquery-data-mart-schema',
-          fields: [
-            {
-              name: 'id',
-              type: 'INTEGER',
-              mode: 'NULLABLE',
-              status: 'CONNECTED',
-              isPrimaryKey: false,
-            },
-            {
-              name: 'created_at',
-              type: 'TIMESTAMP',
-              mode: 'NULLABLE',
-              status: 'CONNECTED',
-              isPrimaryKey: false,
-            },
-          ],
+    await setDataMartSchema(agent, app, dataMartId, {
+      type: 'bigquery-data-mart-schema',
+      fields: [
+        { name: 'id', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED', isPrimaryKey: false },
+        {
+          name: 'created_at',
+          type: 'TIMESTAMP',
+          mode: 'NULLABLE',
+          status: 'CONNECTED',
+          isPrimaryKey: false,
         },
-      });
+      ],
+    });
 
     expect((await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER)).status).toBe(
       200

--- a/apps/backend/test/output-controls-redshift-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-redshift-emission.e2e-spec.ts
@@ -12,6 +12,7 @@ import {
   signLookerPayload,
   mockGoogleJwkFetch,
   restoreGoogleJwkFetch,
+  setDataMartSchema,
 } from '@owox/test-utils';
 import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
 import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
@@ -114,19 +115,14 @@ describe('Output controls — Redshift SQL emission (e2e)', () => {
       .set(AUTH_HEADER)
       .send({ definitionType: 'TABLE', definition: { fullyQualifiedName: 'dev.public.events' } });
 
-    await agent
-      .put(`/api/data-marts/${dataMartId}/schema`)
-      .set(AUTH_HEADER)
-      .send({
-        schema: {
-          type: 'redshift-data-mart-schema',
-          fields: [
-            { name: 'id', type: 'INTEGER', status: 'CONNECTED', isPrimaryKey: false },
-            { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
-            { name: 'name', type: 'VARCHAR', status: 'CONNECTED', isPrimaryKey: false },
-          ],
-        },
-      });
+    await setDataMartSchema(agent, app, dataMartId, {
+      type: 'redshift-data-mart-schema',
+      fields: [
+        { name: 'id', type: 'INTEGER', status: 'CONNECTED', isPrimaryKey: false },
+        { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
+        { name: 'name', type: 'VARCHAR', status: 'CONNECTED', isPrimaryKey: false },
+      ],
+    });
 
     expect((await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER)).status).toBe(
       200

--- a/apps/backend/test/output-controls-snowflake-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-snowflake-emission.e2e-spec.ts
@@ -12,6 +12,7 @@ import {
   signLookerPayload,
   mockGoogleJwkFetch,
   restoreGoogleJwkFetch,
+  setDataMartSchema,
 } from '@owox/test-utils';
 import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
 import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
@@ -113,18 +114,13 @@ describe('Output controls — Snowflake SQL emission (e2e)', () => {
       .set(AUTH_HEADER)
       .send({ definitionType: 'TABLE', definition: { fullyQualifiedName: 'db.sc.events' } });
 
-    await agent
-      .put(`/api/data-marts/${dataMartId}/schema`)
-      .set(AUTH_HEADER)
-      .send({
-        schema: {
-          type: 'snowflake-data-mart-schema',
-          fields: [
-            { name: 'id', type: 'INTEGER', status: 'CONNECTED', isPrimaryKey: false },
-            { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
-          ],
-        },
-      });
+    await setDataMartSchema(agent, app, dataMartId, {
+      type: 'snowflake-data-mart-schema',
+      fields: [
+        { name: 'id', type: 'INTEGER', status: 'CONNECTED', isPrimaryKey: false },
+        { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
+      ],
+    });
 
     expect((await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER)).status).toBe(
       200

--- a/apps/backend/test/output-controls.e2e-spec.ts
+++ b/apps/backend/test/output-controls.e2e-spec.ts
@@ -475,6 +475,7 @@ describe('Output controls API (e2e)', () => {
       cmDataMartId = prereqs.dataMartId;
       cmDataDestinationId = prereqs.dataDestinationId;
 
+      // Seeded CONNECTED on purpose: later saves carry it forward, and blending drops DISCONNECTED columns.
       await setDataMartSchema(agent, app, cmDataMartId, {
         type: 'bigquery-data-mart-schema',
         fields: [
@@ -496,8 +497,7 @@ describe('Output controls API (e2e)', () => {
       cmReportId = createRes.body.id;
     });
 
-    // The next test's save is the first one that actually persists — this one is rejected, so it
-    // leaves the data mart's schema untouched.
+    // Rejected, so it leaves the seeded schema untouched.
     it('PUT schema rejects a formula whose joined path names no source with FORMULA_JOINED_PATH_NOT_FOUND', async () => {
       const res = await agent
         .put(`/api/data-marts/${cmDataMartId}/schema`)

--- a/apps/backend/test/output-controls.e2e-spec.ts
+++ b/apps/backend/test/output-controls.e2e-spec.ts
@@ -8,6 +8,7 @@ import {
   DataDestinationBuilder,
   ReportBuilder,
   AUTH_HEADER,
+  setDataMartSchema,
 } from '@owox/test-utils';
 import { DataDestinationType } from 'src/data-marts/data-destination-types/enums/data-destination-type.enum';
 import { CreateViewService } from 'src/data-marts/use-cases/create-view.service';
@@ -63,19 +64,13 @@ describe('Output controls API (e2e)', () => {
     dataMartId = prereqs.dataMartId;
     dataDestinationId = prereqs.dataDestinationId;
 
-    const schemaRes = await agent
-      .put(`/api/data-marts/${dataMartId}/schema`)
-      .set(AUTH_HEADER)
-      .send({
-        schema: {
-          type: 'bigquery-data-mart-schema',
-          fields: [
-            { name: 'col_a', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
-            { name: 'col_b', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
-          ],
-        },
-      });
-    expect(schemaRes.status).toBe(200);
+    await setDataMartSchema(agent, app, dataMartId, {
+      type: 'bigquery-data-mart-schema',
+      fields: [
+        { name: 'col_a', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+        { name: 'col_b', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+      ],
+    });
 
     // Seed baseline report. LOOKER_STUDIO destinations use a deterministic
     // UUID v5 derived from (dataMartId, dataDestinationId), so there can be
@@ -312,11 +307,7 @@ describe('Output controls API (e2e)', () => {
         ],
       ];
       for (const [id, schema] of schemas) {
-        const res = await agent
-          .put(`/api/data-marts/${id}/schema`)
-          .set(AUTH_HEADER)
-          .send({ schema });
-        expect(res.status).toBe(200);
+        await setDataMartSchema(agent, app, id, schema);
       }
 
       // A LOOKER_STUDIO report id is a UUID v5 of (dataMartId, dataDestinationId), so the
@@ -484,6 +475,14 @@ describe('Output controls API (e2e)', () => {
       cmDataMartId = prereqs.dataMartId;
       cmDataDestinationId = prereqs.dataDestinationId;
 
+      await setDataMartSchema(agent, app, cmDataMartId, {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          { name: 'clicks', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
+          { name: 'impressions', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
+        ],
+      });
+
       const createRes = await agent
         .post('/api/reports')
         .set(AUTH_HEADER)
@@ -648,46 +647,28 @@ describe('Output controls API (e2e)', () => {
       const prereqs = await setupBlendedReportPrerequisites(agent);
       blendMainDataMartId = prereqs.mainDataMartId;
 
-      const mainSchemaRes = await agent
-        .put(`/api/data-marts/${prereqs.mainDataMartId}/schema`)
-        .set(AUTH_HEADER)
-        .send({
-          schema: {
-            type: 'bigquery-data-mart-schema',
-            fields: [
-              { name: 'clicks', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
-              { name: 'impressions', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
-              {
-                name: 'ctr',
-                type: 'FLOAT',
-                mode: 'NULLABLE',
-                status: 'CONNECTED',
-                calculated: { formula: CTR_FORMULA, level: 'metric' },
-              },
-            ],
+      await setDataMartSchema(agent, app, prereqs.mainDataMartId, {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          { name: 'clicks', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
+          { name: 'impressions', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
+          {
+            name: 'ctr',
+            type: 'FLOAT',
+            mode: 'NULLABLE',
+            status: 'CONNECTED',
+            calculated: { formula: CTR_FORMULA, level: 'metric' },
           },
-        });
-      expect(mainSchemaRes.status).toBe(200);
+        ],
+      });
 
       // A declared primary key is what makes `users` an available Unique Count source at all.
-      const usersSchemaRes = await agent
-        .put(`/api/data-marts/${prereqs.usersDataMartId}/schema`)
-        .set(AUTH_HEADER)
-        .send({
-          schema: {
-            type: 'bigquery-data-mart-schema',
-            fields: [
-              {
-                name: 'id',
-                type: 'STRING',
-                mode: 'NULLABLE',
-                status: 'CONNECTED',
-                isPrimaryKey: true,
-              },
-            ],
-          },
-        });
-      expect(usersSchemaRes.status).toBe(200);
+      await setDataMartSchema(agent, app, prereqs.usersDataMartId, {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          { name: 'id', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED', isPrimaryKey: true },
+        ],
+      });
 
       // A fresh destination: the prerequisites' own report already owns the
       // (mainDataMartId, dataDestinationId) pair used by its deterministic LOOKER_STUDIO UUID.

--- a/apps/backend/test/validation-schema.e2e-spec.ts
+++ b/apps/backend/test/validation-schema.e2e-spec.ts
@@ -110,6 +110,63 @@ describe('Validation & Schema API (e2e)', () => {
       draftDataMartId = dataMartRes.body.id;
     });
 
+    it('PUT /api/data-marts/:id/schema - ignores a client-provided connected status', async () => {
+      const updateRes = await agent
+        .put(`/api/data-marts/${draftDataMartId}/schema`)
+        .set(AUTH_HEADER)
+        .send({
+          schema: {
+            type: 'bigquery-data-mart-schema',
+            fields: [
+              {
+                name: 'manual_record',
+                type: 'RECORD',
+                mode: 'NULLABLE',
+                status: 'CONNECTED',
+                fields: [
+                  {
+                    name: 'nested_field',
+                    type: 'STRING',
+                    mode: 'NULLABLE',
+                    status: 'CONNECTED',
+                  },
+                ],
+              },
+            ],
+          },
+        });
+
+      expect(updateRes.status).toBe(200);
+      expect(updateRes.body.schema.fields[0].status).toBe('DISCONNECTED');
+      expect(updateRes.body.schema.fields[0].fields[0].status).toBe('DISCONNECTED');
+
+      const getRes = await agent.get(`/api/data-marts/${draftDataMartId}`).set(AUTH_HEADER);
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.schema.fields[0].status).toBe('DISCONNECTED');
+      expect(getRes.body.schema.fields[0].fields[0].status).toBe('DISCONNECTED');
+    });
+
+    it('PUT /api/data-marts/:id/schema - accepts a field without a client-owned status', async () => {
+      const updateRes = await agent
+        .put(`/api/data-marts/${draftDataMartId}/schema`)
+        .set(AUTH_HEADER)
+        .send({
+          schema: {
+            type: 'bigquery-data-mart-schema',
+            fields: [
+              {
+                name: 'statusless_field',
+                type: 'STRING',
+                mode: 'NULLABLE',
+              },
+            ],
+          },
+        });
+
+      expect(updateRes.status).toBe(200);
+      expect(updateRes.body.schema.fields[0].status).toBe('DISCONNECTED');
+    });
+
     // VALID-05: Validate definition on DataMart without definition returns 200 with valid=false
     it('POST /api/data-marts/:id/validate-definition - returns valid=false with errorMessage', async () => {
       const res = await agent

--- a/apps/backend/test/validation-schema.e2e-spec.ts
+++ b/apps/backend/test/validation-schema.e2e-spec.ts
@@ -167,6 +167,37 @@ describe('Validation & Schema API (e2e)', () => {
       expect(updateRes.body.schema.fields[0].status).toBe('DISCONNECTED');
     });
 
+    it('PUT /api/data-marts/:id/schema - refuses a formula referencing a native field introduced in the same save', async () => {
+      const res = await agent
+        .put(`/api/data-marts/${draftDataMartId}/schema`)
+        .set(AUTH_HEADER)
+        .send({
+          schema: {
+            type: 'bigquery-data-mart-schema',
+            fields: [
+              { name: 'revenue', type: 'FLOAT', mode: 'NULLABLE', status: 'CONNECTED' },
+              {
+                name: 'total_revenue',
+                type: 'FLOAT',
+                mode: 'NULLABLE',
+                calculated: { formula: 'SUM({{ref field="revenue"}})', level: 'metric' },
+              },
+            ],
+          },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.errorDetails.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'FORMULA_UNKNOWN_REFERENCE',
+            field: 'total_revenue',
+            subject: 'revenue',
+          }),
+        ])
+      );
+    });
+
     // VALID-05: Validate definition on DataMart without definition returns 200 with valid=false
     it('POST /api/data-marts/:id/validate-definition - returns valid=false with errorMessage', async () => {
       const res = await agent

--- a/apps/web/e2e/fixtures/api-helpers.ts
+++ b/apps/web/e2e/fixtures/api-helpers.ts
@@ -39,19 +39,22 @@ export function resetDatabase(): void {
   }
 }
 
+function openTestDatabase() {
+  const dbPath = process.env.SQLITE_DB_PATH;
+  if (!dbPath) throw new Error('SQLITE_DB_PATH not set — cannot seed the test database');
+
+  const esmRequire = createRequire(import.meta.url);
+  const Database = esmRequire('better-sqlite3');
+  return new Database(resolve(dbPath));
+}
+
 /**
  * Seeds storage config and a dummy credential directly in the SQLite DB.
  * Required for CONNECTOR definitions — the update-storage API validates
  * against real cloud services, so we bypass it by writing to the DB file.
  */
 function seedStorageConfig(storageId: string): void {
-  const dbPath = process.env.SQLITE_DB_PATH;
-  if (!dbPath) throw new Error('SQLITE_DB_PATH not set — cannot seed storage config');
-
-  const absPath = resolve(dbPath);
-  const esmRequire = createRequire(import.meta.url);
-  const Database = esmRequire('better-sqlite3');
-  const db = new Database(absPath);
+  const db = openTestDatabase();
 
   try {
     const credentialId = randomUUID();
@@ -63,6 +66,24 @@ function seedStorageConfig(storageId: string): void {
       JSON.stringify({ projectId: 'test-project', dataset: 'test_dataset' }),
       credentialId,
       storageId
+    );
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Field statuses are server-owned: the save keeps every native field it cannot verify against
+ * the storage DISCONNECTED, and the e2e storage has no warehouse, so the schema is seeded with
+ * the statuses given before it is saved through the API.
+ */
+function seedDataMartSchema(dataMartId: string, schema: Record<string, unknown>): void {
+  const db = openTestDatabase();
+
+  try {
+    db.prepare(`UPDATE data_mart SET schema = ? WHERE id = ?`).run(
+      JSON.stringify(schema),
+      dataMartId
     );
   } finally {
     db.close();
@@ -104,12 +125,15 @@ export class ApiHelpers {
   }
 
   /**
-   * Writes the output schema directly. `fields` is the storage-specific field list — BigQuery's
-   * shape here, matching the `bigquery-data-mart-schema` type the default test storage uses.
+   * Seeds the output schema with the statuses given, then saves it through the API so calculated
+   * fields get the real save. `fields` is the storage-specific field list — BigQuery's shape here,
+   * matching the `bigquery-data-mart-schema` type the default test storage uses.
    */
   async setSchema(dataMartId: string, fields: Record<string, unknown>[]): Promise<void> {
+    const schema = { type: 'bigquery-data-mart-schema', fields };
+    seedDataMartSchema(dataMartId, schema);
     const res = await this.page.request.put(`/api/data-marts/${dataMartId}/schema`, {
-      data: { schema: { type: 'bigquery-data-mart-schema', fields } },
+      data: { schema },
     });
     expect(res.ok()).toBeTruthy();
   }

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.test.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.test.ts
@@ -4,6 +4,12 @@ import apiClient from '../../../../app/api/apiClient.ts';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum.ts';
 import type { CreateDataMartRequestDto } from '../types/api';
 import { DataMartStatus } from '../enums/data-mart-status.enum.ts';
+import {
+  BigQueryFieldMode,
+  BigQueryFieldType,
+  DataMartSchemaFieldStatus,
+  type DataMartSchema,
+} from '../types/data-mart-schema.types.ts';
 
 vi.mock('../../../../app/api/apiClient.ts', () => ({
   default: {
@@ -127,6 +133,60 @@ describe('DataMartService', () => {
         undefined
       );
       expect(result).toEqual(mockDataMartResponse);
+    });
+  });
+
+  describe('updateDataMartSchema', () => {
+    it('does not send server-owned field statuses', async () => {
+      const schema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'record',
+            type: BigQueryFieldType.RECORD,
+            mode: BigQueryFieldMode.NULLABLE,
+            isPrimaryKey: false,
+            status: DataMartSchemaFieldStatus.CONNECTED,
+            fields: [
+              {
+                name: 'nested_field',
+                type: BigQueryFieldType.STRING,
+                mode: BigQueryFieldMode.NULLABLE,
+                isPrimaryKey: false,
+                status: DataMartSchemaFieldStatus.CONNECTED,
+              },
+            ],
+          },
+        ],
+      } satisfies DataMartSchema;
+
+      await service.updateDataMartSchema(mockDataMartId, { schema });
+
+      expect(apiClient.put).toHaveBeenCalledWith(
+        `/data-marts/${mockDataMartId}/schema`,
+        {
+          schema: {
+            type: 'bigquery-data-mart-schema',
+            fields: [
+              {
+                name: 'record',
+                type: BigQueryFieldType.RECORD,
+                mode: BigQueryFieldMode.NULLABLE,
+                isPrimaryKey: false,
+                fields: [
+                  {
+                    name: 'nested_field',
+                    type: BigQueryFieldType.STRING,
+                    mode: BigQueryFieldMode.NULLABLE,
+                    isPrimaryKey: false,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        { timeout: 180000 }
+      );
     });
   });
 

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
@@ -26,6 +26,7 @@ import type {
 import type { CreateSqlDryRunTaskResponseDto } from '../types/api/response/create-sql-dry-run-task.response.dto.ts';
 import type { TaskStatusResponseDto } from '../types/api/response/task-status.response.dto.ts';
 import type { DataMartInputSourceChangeImpactResponseDto } from '../types/api/response/data-mart-input-source-change-impact.response.dto.ts';
+import type { BaseSchemaField, DataMartSchema } from '../types/data-mart-schema.types.ts';
 
 /**
  * Data Mart Service
@@ -229,10 +230,13 @@ export class DataMartService extends ApiService {
    */
   async updateDataMartSchema(
     id: string,
-    data: UpdateDataMartSchemaRequestDto,
+    data: { schema: DataMartSchema },
     config?: AxiosRequestConfig
   ): Promise<UpdateDataMartSchemaResponseDto> {
-    return this.put<UpdateDataMartSchemaResponseDto>(`/${id}/schema`, data, {
+    const request: UpdateDataMartSchemaRequestDto = {
+      schema: withoutFieldConnectionStatuses(data.schema),
+    };
+    return this.put<UpdateDataMartSchemaResponseDto>(`/${id}/schema`, request, {
       timeout: 180000,
       ...config,
     });
@@ -515,5 +519,23 @@ export class DataMartService extends ApiService {
       skipErrorToast: true,
     } as AxiosRequestConfig);
   }
+}
+
+type SchemaFieldWithChildren = BaseSchemaField & { fields?: SchemaFieldWithChildren[] };
+
+function withoutFieldConnectionStatuses(
+  schema: DataMartSchema
+): UpdateDataMartSchemaRequestDto['schema'] {
+  const withoutStatus = ({ fields, ...field }: SchemaFieldWithChildren): object => {
+    delete (field as Partial<BaseSchemaField>).status;
+    return fields === undefined
+      ? field
+      : { ...field, fields: fields.map(nestedField => withoutStatus(nestedField)) };
+  };
+
+  return {
+    ...schema,
+    fields: (schema.fields as SchemaFieldWithChildren[]).map(field => withoutStatus(field)),
+  } as UpdateDataMartSchemaRequestDto['schema'];
 }
 export const dataMartService = new DataMartService();

--- a/apps/web/src/features/data-marts/shared/types/api/request/update-data-mart-schema.request.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/request/update-data-mart-schema.request.dto.ts
@@ -1,5 +1,13 @@
 import type { DataMartSchema } from '../../data-mart-schema.types.ts';
 
+type WithoutConnectionStatus<T> = T extends readonly unknown[]
+  ? { [Index in keyof T]: WithoutConnectionStatus<T[Index]> }
+  : T extends object
+    ? {
+        [Key in keyof T as Key extends 'status' ? never : Key]: WithoutConnectionStatus<T[Key]>;
+      }
+    : T;
+
 /**
  * Update data mart schema request data transfer object
  */
@@ -7,5 +15,5 @@ export interface UpdateDataMartSchemaRequestDto {
   /**
    * Updated schema of the data mart
    */
-  schema: DataMartSchema;
+  schema: WithoutConnectionStatus<DataMartSchema>;
 }

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -18,6 +18,7 @@ test-utils/
     │   ├── setup-published-data-mart.ts      # setupPublishedDataMart() — SQL definition chain
     │   ├── setup-connector-data-mart.ts      # setupConnectorDataMart() — CONNECTOR definition chain
     │   ├── setup-report-prerequisites.ts     # setupReportPrerequisites() — storage+DM+dest+report
+    │   ├── set-data-mart-schema.ts           # setDataMartSchema() — seed + save an output schema
     │   └── truncate-all-tables.ts            # truncateAllTables() — cleanup helper
     └── fixtures/
         ├── index.ts
@@ -192,6 +193,21 @@ const { storageId, dataMartId, dataDestinationId } = await setupReportPrerequisi
 Uses LOOKER_STUDIO destination type because GOOGLE_SHEETS credential validation calls real Google APIs and will fail in test environments.
 
 **Returns:** `{ storageId: string, dataMartId: string, dataDestinationId: string }`
+
+#### `setDataMartSchema(agent, app, dataMartId, schema)`
+
+Writes an output schema with the field statuses given, then saves it through `PUT /api/data-marts/:id/schema`.
+
+```typescript
+await setDataMartSchema(agent, app, dataMartId, {
+  type: 'bigquery-data-mart-schema',
+  fields: [{ name: 'id', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' }],
+});
+```
+
+Field statuses are server-owned: the save keeps every native field it cannot verify against the storage `DISCONNECTED`, and test storages have no warehouse to actualize against. The helper seeds the schema straight into the database first (the same bypass `setupConnectorDataMart` uses for storage config), so the save carries the seeded statuses forward and calculated fields still go through the real validation.
+
+**Returns:** the `PUT` response.
 
 #### `truncateAllTables(dataSource)`
 

--- a/packages/test-utils/src/helpers/index.ts
+++ b/packages/test-utils/src/helpers/index.ts
@@ -25,6 +25,7 @@ export {
   type SetupGoogleSheetsReportResult,
 } from './setup-google-sheets-report';
 export { setDataMartAlias } from './set-data-mart-alias';
+export { setDataMartSchema } from './set-data-mart-schema';
 export { extractCteBody } from './extract-cte-body';
 export {
   setupBlendedReportPrerequisites,

--- a/packages/test-utils/src/helpers/set-data-mart-schema.ts
+++ b/packages/test-utils/src/helpers/set-data-mart-schema.ts
@@ -2,6 +2,9 @@ import { INestApplication } from '@nestjs/common';
 import * as supertest from 'supertest';
 import { AUTH_HEADER } from '../constants';
 
+const backendDir = require('path').dirname(require.resolve('@owox/backend/package.json'));
+const { DataSource } = require(require.resolve('typeorm', { paths: [backendDir] }));
+
 /**
  * Field statuses are server-owned (a save keeps unverified native fields DISCONNECTED) and the e2e
  * storages have no warehouse to actualize against, so the schema is written straight into the DB
@@ -13,8 +16,6 @@ export async function setDataMartSchema(
   dataMartId: string,
   schema: Record<string, unknown>
 ): Promise<supertest.Response> {
-  const backendDir = require('path').dirname(require.resolve('@owox/backend/package.json'));
-  const { DataSource } = require(require.resolve('typeorm', { paths: [backendDir] }));
   await app
     .get(DataSource)
     .query('UPDATE data_mart SET schema = ? WHERE id = ?', [JSON.stringify(schema), dataMartId]);

--- a/packages/test-utils/src/helpers/set-data-mart-schema.ts
+++ b/packages/test-utils/src/helpers/set-data-mart-schema.ts
@@ -1,0 +1,32 @@
+import { INestApplication } from '@nestjs/common';
+import * as supertest from 'supertest';
+import { AUTH_HEADER } from '../constants';
+
+/**
+ * Field statuses are server-owned (a save keeps unverified native fields DISCONNECTED) and the e2e
+ * storages have no warehouse to actualize against, so the schema is written straight into the DB
+ * with the statuses given, then saved through the API so calculated fields get the real save.
+ */
+export async function setDataMartSchema(
+  agent: supertest.Agent,
+  app: INestApplication,
+  dataMartId: string,
+  schema: Record<string, unknown>
+): Promise<supertest.Response> {
+  const backendDir = require('path').dirname(require.resolve('@owox/backend/package.json'));
+  const { DataSource } = require(require.resolve('typeorm', { paths: [backendDir] }));
+  await app
+    .get(DataSource)
+    .query('UPDATE data_mart SET schema = ? WHERE id = ?', [JSON.stringify(schema), dataMartId]);
+
+  const res = await agent
+    .put(`/api/data-marts/${dataMartId}/schema`)
+    .set(AUTH_HEADER)
+    .send({ schema });
+  if (res.status !== 200) {
+    throw new Error(
+      `PUT /api/data-marts/${dataMartId}/schema failed: ${res.status} ${JSON.stringify(res.body)}`
+    );
+  }
+  return res;
+}

--- a/packages/test-utils/src/helpers/setup-blended-report-prerequisites.ts
+++ b/packages/test-utils/src/helpers/setup-blended-report-prerequisites.ts
@@ -1,9 +1,11 @@
+import { INestApplication } from '@nestjs/common';
 import * as supertest from 'supertest';
 import { AUTH_HEADER } from '../constants';
 import { StorageBuilder } from '../fixtures/storage.builder';
 import { DataMartBuilder } from '../fixtures/data-mart.builder';
 import { DataDestinationBuilder } from '../fixtures/data-destination.builder';
 import { ReportBuilder } from '../fixtures/report.builder';
+import { setDataMartSchema } from './set-data-mart-schema';
 import { DataDestinationType } from '../../../../apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum';
 
 /**
@@ -74,32 +76,22 @@ export const ORGS_SCHEMA = {
 
 // ── Options ─────────────────────────────────────────────────────────────────
 
-export interface SetupBlendedReportOptions {
-  /**
-   * When true, sets real BigQuery schemas on all three data marts via
-   * `PUT /api/data-marts/:id/schema`.  This unlocks native-column validation
-   * paths (FILTER_COLUMN_UNKNOWN, SORT_COLUMN_NOT_SELECTED on native columns)
-   * and allows BlendableSchemaService to run without any mock.
-   *
-   * Default: false — preserves the original bootstrap behaviour (empty schema,
-   * fast, does not break suites that mock the schema service themselves).
-   */
-  withSchemas?: boolean;
-}
-
-// ── Helper: set schema via real API ─────────────────────────────────────────
-
-async function setSchema(
-  agent: supertest.Agent,
-  dataMartId: string,
-  schema: Record<string, unknown>
-): Promise<void> {
-  const res = await agent
-    .put(`/api/data-marts/${dataMartId}/schema`)
-    .set(AUTH_HEADER)
-    .send({ schema });
-  expect(res.status).toBe(200);
-}
+export type SetupBlendedReportOptions =
+  | { withSchemas?: false }
+  | {
+      /**
+       * Sets real BigQuery schemas on all three data marts through
+       * {@link setDataMartSchema}.  This unlocks native-column validation
+       * paths (FILTER_COLUMN_UNKNOWN, SORT_COLUMN_NOT_SELECTED on native columns)
+       * and allows BlendableSchemaService to run without any mock.
+       *
+       * Omitted: preserves the original bootstrap behaviour (empty schema,
+       * fast, does not break suites that mock the schema service themselves).
+       */
+      withSchemas: true;
+      /** The test app the schemas are seeded into. */
+      app: INestApplication;
+    };
 
 /**
  * Bootstraps a fully-wired blended report through the REST API only.
@@ -135,7 +127,7 @@ async function setSchema(
  *   returned `reportId` across `it` blocks is the intended usage pattern.
  *
  * @param agent  A supertest agent bound to a running test NestJS app.
- * @param opts   Optional configuration.  Pass `{ withSchemas: true }` to seed
+ * @param opts   Optional configuration.  Pass `{ withSchemas: true, app }` to seed
  *               BigQuery schemas on all three data marts so native-column filter
  *               and sort validation paths are exercisable without mocking
  *               BlendableSchemaService.
@@ -191,13 +183,13 @@ export async function setupBlendedReportPrerequisites(
   const orgsDataMartId = await createPublishedDataMart('Blended Test - orgs');
 
   // ── Step 3b (opt-in): Seed real BigQuery schemas ──────────────────────────
-  //   When withSchemas is true, set typed field schemas via the real API so
+  //   When withSchemas is true, seed typed field schemas so
   //   BlendableSchemaService.computeBlendableSchema returns native + blended
   //   fields without any mock.  This unlocks native-column validation paths.
   if (opts.withSchemas) {
-    await setSchema(agent, mainDataMartId, EVENTS_SCHEMA);
-    await setSchema(agent, usersDataMartId, USERS_SCHEMA);
-    await setSchema(agent, orgsDataMartId, ORGS_SCHEMA);
+    await setDataMartSchema(agent, opts.app, mainDataMartId, EVENTS_SCHEMA);
+    await setDataMartSchema(agent, opts.app, usersDataMartId, USERS_SCHEMA);
+    await setDataMartSchema(agent, opts.app, orgsDataMartId, ORGS_SCHEMA);
   }
 
   // ── Step 4: Create relationships on the home data mart ────────────────────


### PR DESCRIPTION
Changeset: `.changeset/6935-output-schema-field-connection-status.md` (`owox`, `minor`)

## Summary

A field's connection status in the output schema (`CONNECTED`, `CONNECTED_WITH_DEFINITION_MISMATCH`, `DISCONNECTED`) is derived by schema actualization against the storage. Until now `PUT /api/data-marts/:id/schema` accepted whatever status the client sent, so an API user or a plugin could save a column as `CONNECTED` before the storage had verified it and immediately use it in reports. The status is now read-only for the API: the save derives it on the server, older clients that still send it keep working, and the web app no longer sends it.

## What changed

### Backend

- `PUT /api/data-marts/:id/schema` ignores the client status and applies server-owned statuses to the parsed schema: a native field keeps the last persisted status of its namesake, a new native field starts `DISCONNECTED` until actualization verifies it, a calculated field is always `CONNECTED`. Nested `RECORD` fields are handled recursively.
- The zod field schema gives `status` a `DISCONNECTED` default, so the field is optional on the wire for all five storage types. A legacy row without a status now loads instead of failing the entity transformer.
- `UpdateDataMartSchemaApiDto` and the command carry a status-less `DataMartSchemaUpdate` type derived from the zod input type; the Swagger description spells out the rule and points at `POST /data-marts/{id}/schema-actualize-triggers` for refreshing statuses.

### Web

- `dataMartService.updateDataMartSchema` strips `status` from every field, nested ones included, before the request; the request DTO type excludes it. The feature type keeps `status` for display.

### Tests and fixtures

- Unit: server-owned derivation (persisted carry-forward, nested carry-forward, new native and calculated fields, a native field submitted under a persisted calculated field's name), plus the web strip.
- API e2e: a client-provided `CONNECTED` is ignored (nested included) and a field without status is accepted.
- The e2e fixtures used `PUT /schema` to declare native columns as `CONNECTED` on Data Marts that have no warehouse behind them, which is exactly what the endpoint no longer does. They now go through `setDataMartSchema` (`@owox/test-utils`), which seeds the schema with the given statuses straight into the test database, the same bypass both e2e layers already use for storage config, and then saves it through the API so calculated fields still get the real validation. The Playwright `setSchema` fixture does the same against the sqlite test file. No product code changed for this.

## Compatibility

- Wire format: unchanged. Requests with `status` return 200; the value is ignored.
- Semantics: a client can no longer make a column usable by declaring it connected. After a manual save, run schema actualization to get real statuses; the web app already does this after Save.
- Rolling update: a browser that loaded the new web bundle can hit a pod on the previous release during the rollout of `owox-data-marts-webserver`. That pod still requires `status` and answers 400 on schema save until the rollout completes. Self-heals on retry, no data loss in either direction.
- Other clients checked: Google Sheets extension (reads only, responses still carry `status`), `owox-mcp`, `odm-looker-studio`, backend MCP tools, CLI. Nothing else writes a schema.

## Verification

| Check | Result |
| --- | --- |
| Backend unit, full | 613 suites, 9445 tests passed |
| Web unit, full | 261 files, 2422 tests passed |
| API e2e, full (`jest --config test/jest-e2e.json`) | 54 suites, 717 tests passed |
| Playwright: `datamart-calculated-field-chips`, `datamart-calculated-field-formula`, `datamart-row-level-calculated-field` | 25 passed |
| Red-green of the new unit tests | the two new carry-forward tests fail with the recursion and the calculated guard removed, pass with them restored |
| tsc (backend build config, web), eslint, prettier, markdownlint | clean |

Two earlier full API e2e runs each had one transport-level failure in an unrelated suite (503, `socket hang up`), green in isolation and in the other runs.

## Notes for reviewers

- The changeset filename uses Fibery Work Item `6935`; please confirm it is the owning item.
- Pre-existing full `tsc -p tsconfig.json` errors in unrelated `*.spec.ts` files are untouched (same count before and after).
