### PR TITLE
feat(web): add AI assistant promo to the project Reports page

### DIFF
--- a/.changeset/6798-reports-page-connect-ai-assistant-promo.md
+++ b/.changeset/6798-reports-page-connect-ai-assistant-promo.md
@@ -1,0 +1,19 @@
+---
+'owox': minor
+---
+
+# Reports page: prompt to connect Claude or ChatGPT
+
+The project Reports page now shows a promo block beneath the reports list
+inviting you to connect an AI assistant. Ask questions about your data in plain
+language and get answers drawn straight from your published Data Marts, instead
+of numbers an assistant guessed on its own.
+
+The block offers two equal choices — **Claude** and **ChatGPT**. Each button
+opens that assistant's OWOX Data Marts connector page in a new tab, and a link
+to the [MCP setup guide](https://docs.owox.com/docs/getting-started/setup-guide/mcp/)
+walks through the setup. This is the same connection previously offered only in
+the onboarding Setup Checklist, now discoverable where you work with reports.
+
+When the project has no reports yet, the empty state carries a compact hint with
+the same link to the MCP setup guide.

--- a/apps/web/src/pages/data-marts/reports/AiAssistantHintCard.tsx
+++ b/apps/web/src/pages/data-marts/reports/AiAssistantHintCard.tsx
@@ -1,0 +1,46 @@
+import { HelpCircle } from 'lucide-react';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@owox/ui/components/tooltip';
+
+const MCP_SETUP_GUIDE_URL = 'https://docs.owox.com/docs/getting-started/setup-guide/mcp/';
+
+/**
+ * Compact hint shown under the Reports empty state. Points analysts to the MCP
+ * connection so they can query their Data Marts from Claude or ChatGPT before
+ * any report exists. Visual style mirrors InviteTeammatesCard's `card` variant.
+ * Purely presentational; both links open the MCP setup guide in a new tab.
+ */
+export function AiAssistantHintCard() {
+  return (
+    <div className='bg-muted/50 text-muted-foreground dark:text-muted-foreground/75 flex items-center justify-between gap-4 rounded-md border-b border-gray-200 px-4 py-3 text-sm dark:border-white/2 dark:bg-white/2'>
+      <div className='flex min-w-0 items-center gap-2'>
+        <a
+          href={MCP_SETUP_GUIDE_URL}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='hover:text-foreground flex min-w-0 items-center gap-1.5 font-medium transition-colors hover:underline'
+        >
+          <span className='truncate underline'>Ask your data in Claude or ChatGPT</span>
+        </a>
+        <span className='text-muted-foreground/75 dark:text-muted-foreground/50 hidden truncate lg:inline'>
+          — set up the MCP connection
+        </span>
+      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <a
+            href={MCP_SETUP_GUIDE_URL}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='text-muted-foreground/75 dark:text-muted-foreground/50 hover:text-foreground'
+            aria-label='MCP setup guide'
+          >
+            <HelpCircle className='h-4 w-4 shrink-0' />
+          </a>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>MCP setup guide</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}

--- a/apps/web/src/pages/data-marts/reports/ConnectAiAssistantPromoActions.tsx
+++ b/apps/web/src/pages/data-marts/reports/ConnectAiAssistantPromoActions.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@owox/ui/components/button';
+import { ChatGPTIcon, ClaudeIcon } from '../../../shared/icons';
+
+const CLAUDE_DIRECTORY_URL = 'https://claude.ai/directory/owox-data-marts';
+const CHATGPT_PLUGIN_URL =
+  'https://chatgpt.com/plugins/plugin_asdk_app_6a3e81be8f8481918e1e2cd1d7ea09c4';
+const MCP_SETUP_GUIDE_URL = 'https://docs.owox.com/docs/getting-started/setup-guide/mcp/';
+
+/**
+ * Actions for the "Get answers in Claude or ChatGPT" promo block on the project
+ * Reports page: left-aligned outline buttons (icon + label) linking to the OWOX
+ * Data Marts connector in Claude and ChatGPT, wrapping onto a second line on
+ * narrow viewports, plus a link to the MCP setup guide. Every link opens in a
+ * new tab. Purely presentational, no side effects.
+ */
+export function ConnectAiAssistantPromoActions() {
+  return (
+    <div className='flex flex-col items-start gap-3'>
+      <div className='flex w-full flex-col justify-center gap-2 xl:flex-row xl:justify-start xl:gap-4'>
+        <Button size='sm' variant='outline' asChild className='xl:min-w-[140px]'>
+          <a href={CLAUDE_DIRECTORY_URL} target='_blank' rel='noopener noreferrer'>
+            <ClaudeIcon size={16} />
+            Claude
+          </a>
+        </Button>
+        <Button size='sm' variant='outline' asChild className='xl:min-w-[140px]'>
+          <a href={CHATGPT_PLUGIN_URL} target='_blank' rel='noopener noreferrer'>
+            <ChatGPTIcon size={16} />
+            ChatGPT
+          </a>
+        </Button>
+      </div>
+      <div className='flex w-full justify-center xl:justify-start'>
+        <a
+          href={MCP_SETUP_GUIDE_URL}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='text-muted-foreground hover:text-foreground text-xs underline underline-offset-2'
+        >
+          How to set up the MCP connection
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router';
 import type { ColumnDef } from '@tanstack/react-table';
 import RelativeTime from '@owox/ui/components/common/relative-time';
 import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
+import { Cog } from 'lucide-react';
 import { extractApiError } from '../../../app/api';
 import { DataDestinationType, DataDestinationTypeModel } from '../../../features/data-destination';
 import { DataMartContext } from '../../../features/data-marts/edit/model/context/context';
@@ -20,6 +21,7 @@ import { ReportQuickRunCell } from '../../../features/data-marts/reports/shared'
 import type { DataMartReport } from '../../../features/data-marts/reports/shared/model/types/data-mart-report';
 import { ReportStatusEnum } from '../../../features/data-marts/reports/shared/enums';
 import { reportService } from '../../../features/data-marts/reports/shared/services';
+import { PromoBlock } from '../../../shared/components/PromoBlock/PromoBlock';
 import { BaseTable, SortableHeader, ToggleColumnsHeader } from '../../../shared/components/Table';
 import {
   applyFiltersToData,
@@ -40,6 +42,8 @@ import { buildProjectDataMartContextValue } from '../shared/projectDataMartConte
 import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
 import { ProjectDataMartSectionHeader } from '../shared/ProjectDataMartSectionHeader';
 import { ProjectDataMartTitleLink } from '../shared/ProjectDataMartTitleLink';
+import { AiAssistantHintCard } from './AiAssistantHintCard';
+import { ConnectAiAssistantPromoActions } from './ConnectAiAssistantPromoActions';
 import { mergeReportPagePreservingRows } from './DataMartReportsPage.utils';
 import {
   ReportGeneratedSqlAction,
@@ -492,41 +496,53 @@ export default function DataMartReportsPage() {
           ) : error ? (
             <div className='dm-card-block text-destructive text-sm'>{error}</div>
           ) : reports.length === 0 ? (
-            <div className='dm-card'>
-              <ProjectDataMartEmptyState variant='reports' />
+            <div className='flex flex-col gap-0.5'>
+              <div className='dm-card'>
+                <ProjectDataMartEmptyState variant='reports' />
+              </div>
+              <AiAssistantHintCard />
             </div>
           ) : (
-            <div className='dm-card' data-testid='projectReportsTable'>
-              <BaseTable
-                tableId={PROJECT_REPORTS_TABLE_ID}
-                table={table}
-                ariaLabel='Project Data Mart Reports'
-                paginationProps={{ displaySelected: false }}
-                renderToolbarLeft={() => (
-                  <>
-                    <ProjectDataMartTableFilters
-                      appliedState={appliedState}
-                      config={filtersConfig}
-                      onApply={apply}
-                      onClear={clear}
-                    />
-                    <ProjectDataMartTableSearch value={searchQuery} onChange={setSearchQuery} />
-                  </>
-                )}
-                renderEmptyState={() => (
-                  <div
-                    className='flex h-32 items-center justify-center text-center'
-                    role='status'
-                    aria-live='polite'
-                  >
-                    No reports found for accessible Data Marts
-                  </div>
-                )}
-                onRowClick={row => {
-                  if (row.original.canEditConfig) {
-                    handleEditReport(row.original);
-                  }
-                }}
+            <div className='flex flex-col gap-4'>
+              <div className='dm-card' data-testid='projectReportsTable'>
+                <BaseTable
+                  tableId={PROJECT_REPORTS_TABLE_ID}
+                  table={table}
+                  ariaLabel='Project Data Mart Reports'
+                  paginationProps={{ displaySelected: false }}
+                  renderToolbarLeft={() => (
+                    <>
+                      <ProjectDataMartTableFilters
+                        appliedState={appliedState}
+                        config={filtersConfig}
+                        onApply={apply}
+                        onClear={clear}
+                      />
+                      <ProjectDataMartTableSearch value={searchQuery} onChange={setSearchQuery} />
+                    </>
+                  )}
+                  renderEmptyState={() => (
+                    <div
+                      className='flex h-32 items-center justify-center text-center'
+                      role='status'
+                      aria-live='polite'
+                    >
+                      No reports found for accessible Data Marts
+                    </div>
+                  )}
+                  onRowClick={row => {
+                    if (row.original.canEditConfig) {
+                      handleEditReport(row.original);
+                    }
+                  }}
+                />
+              </div>
+              <PromoBlock
+                icon={Cog}
+                size='compact'
+                title='Get answers in Claude or ChatGPT'
+                description='Ask in plain language and get answers pulled straight from your Data Marts, not guesses. Connect via Claude or ChatGPT — whichever your team already uses.'
+                actions={<ConnectAiAssistantPromoActions />}
               />
             </div>
           )}

--- a/apps/web/src/shared/components/PromoBlock/PromoBlock.tsx
+++ b/apps/web/src/shared/components/PromoBlock/PromoBlock.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Button } from '@owox/ui/components/button';
 import { ExternalLinkIcon } from 'lucide-react';
 import { cn } from '@owox/ui/lib/utils';
@@ -17,8 +18,15 @@ export interface PromoBlockProps {
   description?: string;
   subtitle?: string;
 
-  primaryAction: Action;
+  primaryAction?: Action;
   secondaryAction?: Action;
+
+  /**
+   * Custom actions node. When provided it replaces the built-in
+   * primary/secondary buttons — use it for calls to action the two-button model
+   * can't express (e.g. multiple equal links with icons).
+   */
+  actions?: ReactNode;
 
   className?: string;
 
@@ -88,6 +96,7 @@ export function PromoBlock({
   subtitle,
   primaryAction,
   secondaryAction,
+  actions,
   className,
   size = 'default',
   backgroundImageLight,
@@ -142,7 +151,7 @@ export function PromoBlock({
 
     description: cn(
       'text-muted-foreground leading-relaxed dark:text-white/80',
-      isCompact ? 'text-sm mb-4 xl:mb-8' : 'text-base md:text-lg mb-8'
+      isCompact ? 'text-sm mb-4 3xl:mb-8' : 'text-base md:text-lg mb-8'
     ),
 
     actions: cn(
@@ -191,14 +200,17 @@ export function PromoBlock({
           <h2 className={styles.title}>{title}</h2>
           {description && <p className={styles.description}>{description}</p>}
 
-          <div className={styles.actions}>
-            {renderAction(primaryAction, { size: isCompact ? 'sm' : 'lg' })}
-            {secondaryAction &&
-              renderAction(secondaryAction, {
-                variant: 'outline',
-                size: isCompact ? 'sm' : 'lg',
-              })}
-          </div>
+          {actions ??
+            (primaryAction && (
+              <div className={styles.actions}>
+                {renderAction(primaryAction, { size: isCompact ? 'sm' : 'lg' })}
+                {secondaryAction &&
+                  renderAction(secondaryAction, {
+                    variant: 'outline',
+                    size: isCompact ? 'sm' : 'lg',
+                  })}
+              </div>
+            ))}
         </div>
 
         {/* Visual */}


### PR DESCRIPTION
## What & why

The "connect an AI assistant" flow — query your Data Marts from Claude or
ChatGPT over MCP — previously lived only in the onboarding Setup Checklist.
This surfaces it on the project **Reports** page, where analysts actually work
with report output, so it stays discoverable after onboarding.

<img width="2088" height="2707" alt="Frame 23137627" src="https://github.com/user-attachments/assets/f3a2105d-7c70-45e7-bc3a-4afd0e02d4b5" />

<img width="1518" height="2074" alt="Frame 23137628" src="https://github.com/user-attachments/assets/124f914b-5bf2-439d-ac24-6ec4c5c8d932" />

<img width="1518" height="1233" alt="Frame 23137629" src="https://github.com/user-attachments/assets/3c23d1f6-fa61-429b-86b8-a3b6a5952367" />


## Changes

- **Reports page (with reports):** a compact `PromoBlock` under the reports
  table — "Get answers in Claude or ChatGPT" with **Claude** / **ChatGPT**
  buttons that open each assistant's OWOX Data Marts connector in a new tab,
  plus a link to the
  [MCP setup guide](https://docs.owox.com/docs/getting-started/setup-guide/mcp/).
- **Reports page (empty state):** a small hint strip under the empty state with
  the same MCP setup guide link — a full promo block would be too heavy there.
- **`PromoBlock` component:** new optional `actions` slot (a custom node that
  replaces the built-in primary/secondary buttons for CTAs the two-button model
  can't express); `primaryAction` is now optional. The four existing usages are
  unchanged.
- New co-located components: `ConnectAiAssistantPromoActions.tsx` (icon buttons
  + guide link, left-aligned, wraps on narrow viewports) and
  `AiAssistantHintCard.tsx` (empty-state strip).
