### PR TITLE
feat(web): sort projects in the switcher alphabetically

### DIFF
--- a/.changeset/6922-sort-projects-alphabetically.md
+++ b/.changeset/6922-sort-projects-alphabetically.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Projects in the switcher are sorted alphabetically
+
+The **Switch project** menu now lists your projects in alphabetical order instead of the order the server happened to return them in, so a project always sits where you expect it.
+
+Sorting ignores letter case, so `alpha` and `Alpha` are ordered together, and it reads numbers as numbers: _Project 2_ comes before _Project 10_.

--- a/apps/web/src/components/AppSidebar/ProjectMenu/SwitchProjectMenu.test.tsx
+++ b/apps/web/src/components/AppSidebar/ProjectMenu/SwitchProjectMenu.test.tsx
@@ -337,6 +337,30 @@ describe('SwitchProjectMenu', () => {
     // First item should still be highlighted
     expect(screen.getByText('Project 1').closest('[role="option"]')).toHaveClass('bg-accent');
   });
+
+  it('lists projects alphabetically regardless of the order returned by the API', () => {
+    projectsState.value = {
+      ...projectsState.value,
+      projects: [
+        { id: 'project-2', title: 'zeta project' },
+        { id: 'project-1', title: 'Beta project' },
+        { id: 'project-3', title: 'Project 10' },
+        { id: 'project-4', title: 'Project 2' },
+        { id: 'project-5', title: 'alpha project' },
+      ],
+      callState: RequestStatus.LOADED,
+    };
+
+    renderSwitchProjectMenu(<SwitchProjectMenu />);
+
+    expect(screen.getAllByRole('option').map(item => item.textContent)).toEqual([
+      'alpha project',
+      'Beta project',
+      'Project 2',
+      'Project 10',
+      'zeta project',
+    ]);
+  });
 });
 
 function renderSwitchProjectMenu(children: ReactNode) {

--- a/apps/web/src/components/AppSidebar/ProjectMenu/SwitchProjectMenu.tsx
+++ b/apps/web/src/components/AppSidebar/ProjectMenu/SwitchProjectMenu.tsx
@@ -15,6 +15,9 @@ import { useProjects } from '../../../features/idp/hooks/useProjects.ts';
 import { RequestStatus } from '../../../shared/types/request-status.ts';
 import { buildProjectPath } from '../../../utils/path.ts';
 
+// Case-insensitive, digit-aware ordering so "Project 2" precedes "Project 10".
+const projectTitleCollator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
+
 interface SwitchProjectMenuProps {
   autoLoad?: boolean;
   emptyMessage?: string;
@@ -36,9 +39,10 @@ function SwitchProjectMenuInner({
   const itemRefs = useRef<(HTMLElement | null)[]>([]);
 
   const visibleProjects = useMemo(() => {
-    return excludeCurrentProject
+    const available = excludeCurrentProject
       ? projects.filter(project => project.id !== user?.projectId)
       : projects;
+    return [...available].sort((a, b) => projectTitleCollator.compare(a.title, b.title));
   }, [projects, excludeCurrentProject, user?.projectId]);
 
   const isInitialLoad = autoLoad && callState === RequestStatus.IDLE;


### PR DESCRIPTION
## What

The **Switch project** menu listed projects in whatever order the projects API returned, so a project could sit anywhere in a long list. It now renders them alphabetically.

## How

`SwitchProjectMenu` sorts its visible projects by title with a module-level `Intl.Collator` (`sensitivity: 'base'`, `numeric: true`):

- case-insensitive, so `alpha` and `Alpha` order together;
- digit-aware, so *Project 2* precedes *Project 10*.

Sorting happens on a copy, before the search filter, so the order holds both in the full list and in search results, and keyboard navigation follows what is on screen.

## Testing

- New unit test in `SwitchProjectMenu.test.tsx` asserts the rendered order for an unsorted API response.
- `npx vitest run apps/web/src/components/AppSidebar/ProjectMenu/SwitchProjectMenu.test.tsx --root apps/web` — 12 passed.
- `npm run type-check -w @owox/web` and ESLint on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)