### PR TITLE
feat(connectors): pick the Google Sheets tab from a list and tidy the setup form

### DIFF
--- a/.changeset/6950-google-sheets-config-ux.md
+++ b/.changeset/6950-google-sheets-config-ux.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Google Sheets source: pick the sheet tab from a list and a leaner setup form
+
+The Google Sheets source setup now lists the tabs of the selected spreadsheet so the Sheet Name can be picked instead of typed, for both Google OAuth and Service Account authentication. With Google OAuth the spreadsheet is chosen with Google Picker only, so the manual "Spreadsheet ID or URL" input no longer appears in that mode. Header Row and Range moved to Advanced Settings because most sheets keep their headers in the first row and import the whole tab.

--- a/apps/backend/src/data-marts/connector-types/connector-field-options.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-field-options.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+/**
+ * Allowed values of a connector configuration field resolved from the source
+ * at configuration time (fields declared with the DYNAMIC_OPTIONS attribute).
+ */
+export const ConnectorFieldOptions = z.array(
+  z.object({
+    value: z.string(),
+    label: z.string(),
+  })
+);
+
+export type ConnectorFieldOptions = z.infer<typeof ConnectorFieldOptions>;

--- a/apps/backend/src/data-marts/connector-types/connector-specification.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-specification.ts
@@ -15,6 +15,11 @@ export const ConnectorSpecificationItem = z.object({
   placeholder: z.string().optional(),
   minimum: z.number().optional(),
   attributes: z.array(z.string()).optional(),
+  /**
+   * Configuration fields whose values are needed before the dynamic options of
+   * this field can be resolved (only meaningful with the DYNAMIC_OPTIONS attribute).
+   */
+  optionsDependsOn: z.array(z.string()).optional(),
   oauthParams: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/apps/backend/src/data-marts/controllers/connector.controller.ts
+++ b/apps/backend/src/data-marts/controllers/connector.controller.ts
@@ -6,6 +6,7 @@ import {
   GetConnectorSpecificationSpec,
   GetConnectorFieldsSpec,
   PreviewConnectorFieldsSpec,
+  PreviewConnectorFieldOptionsSpec,
   ExchangeOAuthCredentialsSpec,
   GetConnectorOAuthStatusSpec,
   GetConnectorOAuthSettingsSpec,
@@ -31,6 +32,9 @@ import { ConnectorOAuthStatusResponseApiDto } from '../dto/presentation/connecto
 import { ConnectorOAuthSettingsResponseApiDto } from '../dto/presentation/connector-oauth-settings-response-api.dto';
 import { ConnectorFieldsPreviewService } from '../services/connector/connector-fields-preview.service';
 import { ConnectorFieldsPreviewRequestApiDto } from '../dto/presentation/connector-fields-preview-request-api.dto';
+import { ConnectorFieldOptionsPreviewService } from '../services/connector/connector-field-options-preview.service';
+import { ConnectorFieldOptionsPreviewRequestApiDto } from '../dto/presentation/connector-field-options-preview-request-api.dto';
+import { ConnectorFieldOptionResponseApiDto } from '../dto/presentation/connector-field-option-response-api.dto';
 
 @Controller('connectors')
 @ApiTags('Connectors')
@@ -40,6 +44,7 @@ export class ConnectorController {
     private readonly specificationConnectorService: SpecificationConnectorService,
     private readonly fieldsConnectorService: FieldsConnectorService,
     private readonly connectorFieldsPreviewService: ConnectorFieldsPreviewService,
+    private readonly connectorFieldOptionsPreviewService: ConnectorFieldOptionsPreviewService,
     private readonly mapper: ConnectorMapper,
     private readonly connectorOauthService: ConnectorOauthService
   ) {}
@@ -86,6 +91,23 @@ export class ConnectorController {
       body.configuration ?? {}
     );
     return this.mapper.toFieldsResponse(fields);
+  }
+
+  @Auth(Role.editor())
+  @Post(':connectorName/options/preview')
+  @PreviewConnectorFieldOptionsSpec()
+  async previewConnectorFieldOptions(
+    @AuthContext() context: AuthorizationContext,
+    @Param('connectorName') connectorName: string,
+    @Body() body: ConnectorFieldOptionsPreviewRequestApiDto
+  ): Promise<ConnectorFieldOptionResponseApiDto[]> {
+    const options = await this.connectorFieldOptionsPreviewService.run(
+      context,
+      connectorName,
+      body.field,
+      body.configuration ?? {}
+    );
+    return this.mapper.toFieldOptionsResponse(options);
   }
 
   @Auth(Role.viewer())

--- a/apps/backend/src/data-marts/controllers/oauth-flow-only.controller.spec.ts
+++ b/apps/backend/src/data-marts/controllers/oauth-flow-only.controller.spec.ts
@@ -40,6 +40,7 @@ jest.mock('../use-cases/connector/available-connector.service', () => ({}));
 jest.mock('../use-cases/connector/specification-connector.service', () => ({}));
 jest.mock('../use-cases/connector/fields-connector.service', () => ({}));
 jest.mock('../services/connector/connector-fields-preview.service', () => ({}));
+jest.mock('../services/connector/connector-field-options-preview.service', () => ({}));
 jest.mock('../mappers/connector.mapper', () => ({}));
 jest.mock('../services/connector/connector-oauth.service', () => ({}));
 jest.mock('../use-cases/create-data-destination.service', () => ({}));

--- a/apps/backend/src/data-marts/controllers/spec/connector.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/connector.api.ts
@@ -16,6 +16,8 @@ import { ConnectorOAuthStatusResponseApiDto } from '../../dto/presentation/conne
 import { ConnectorOAuthSettingsResponseApiDto } from '../../dto/presentation/connector-oauth-settings-response-api.dto';
 import { ExchangeOAuthCredentialsDto } from '../../dto/presentation/exchange-oauth-credentials.dto';
 import { ConnectorFieldsPreviewRequestApiDto } from '../../dto/presentation/connector-fields-preview-request-api.dto';
+import { ConnectorFieldOptionsPreviewRequestApiDto } from '../../dto/presentation/connector-field-options-preview-request-api.dto';
+import { ConnectorFieldOptionResponseApiDto } from '../../dto/presentation/connector-field-option-response-api.dto';
 
 export function GetAvailableConnectorsSpec() {
   return applyDecorators(
@@ -52,6 +54,23 @@ export function PreviewConnectorFieldsSpec() {
     ApiResponse({ status: 403, description: 'Connector credentials cannot access the resource' }),
     ApiResponse({ status: 502, description: 'Connector provider is unavailable' }),
     ApiResponse({ status: 504, description: 'Connector field preview timed out' })
+  );
+}
+
+export function PreviewConnectorFieldOptionsSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Preview the allowed values of a connector configuration field',
+      description:
+        'Resolves the options of a field declared with the DYNAMIC_OPTIONS attribute from the source, for example the sheet tabs of the selected spreadsheet.',
+    }),
+    ApiParam({ name: 'connectorName', description: 'Connector name' }),
+    ApiBody({ type: ConnectorFieldOptionsPreviewRequestApiDto }),
+    ApiOkResponse({ type: ConnectorFieldOptionResponseApiDto, isArray: true }),
+    ApiResponse({ status: 400, description: 'Unable to preview connector field options' }),
+    ApiResponse({ status: 403, description: 'Connector credentials cannot access the resource' }),
+    ApiResponse({ status: 502, description: 'Connector provider is unavailable' }),
+    ApiResponse({ status: 504, description: 'Connector field options preview timed out' })
   );
 }
 

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -159,6 +159,7 @@ import { ConnectorMapper } from './mappers/connector.mapper';
 import { SpecificationConnectorService } from './use-cases/connector/specification-connector.service';
 import { FieldsConnectorService } from './use-cases/connector/fields-connector.service';
 import { ConnectorFieldsPreviewService } from './services/connector/connector-fields-preview.service';
+import { ConnectorFieldOptionsPreviewService } from './services/connector/connector-field-options-preview.service';
 import { RunDataMartService } from './use-cases/run-data-mart.service';
 import { CancelDataMartRunService } from './use-cases/cancel-data-mart-run.service';
 import { ValidateDataMartDefinitionService } from './use-cases/validate-data-mart-definition.service';
@@ -766,6 +767,7 @@ import { ConsentCredentialDefinitionService } from './credentials/use-cases/cons
     SpecificationConnectorService,
     FieldsConnectorService,
     ConnectorFieldsPreviewService,
+    ConnectorFieldOptionsPreviewService,
     RunDataMartService,
     CancelDataMartRunService,
     SqlDryRunService,

--- a/apps/backend/src/data-marts/dto/presentation/connector-field-option-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/connector-field-option-response-api.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ConnectorFieldOptionResponseApiDto {
+  @ApiProperty({ example: 'Sheet1', description: 'Value to store in the configuration' })
+  value: string;
+
+  @ApiProperty({ example: 'Sheet1', description: 'Human-readable label' })
+  label: string;
+}

--- a/apps/backend/src/data-marts/dto/presentation/connector-field-options-preview-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/connector-field-options-preview-request-api.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsObject, IsString } from 'class-validator';
+
+export class ConnectorFieldOptionsPreviewRequestApiDto {
+  @ApiProperty({
+    example: 'SheetName',
+    description: 'Configuration field declared with the DYNAMIC_OPTIONS attribute.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  field: string;
+
+  @ApiProperty({
+    type: Object,
+    description:
+      'Connector source configuration. Only the fields listed in optionsDependsOn of the requested field have to be filled.',
+  })
+  @IsObject()
+  configuration: Record<string, unknown>;
+}

--- a/apps/backend/src/data-marts/dto/presentation/connector-specification-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/connector-specification-response-api.dto.ts
@@ -43,6 +43,15 @@ export class ConnectorSpecificationItemResponseApiDto {
     required: false,
   })
   attributes?: string[];
+
+  @ApiProperty({
+    type: [String],
+    example: ['AuthType', 'SpreadsheetId'],
+    required: false,
+    description:
+      'Configuration fields that must be filled before the dynamic options of this field can be loaded (DYNAMIC_OPTIONS attribute).',
+  })
+  optionsDependsOn?: string[];
 }
 
 export class ConnectorSpecificationOneOfOptionResponseApiDto {

--- a/apps/backend/src/data-marts/mappers/connector.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/connector.mapper.ts
@@ -6,6 +6,8 @@ import {
   ConnectorSpecificationItem,
 } from '../connector-types/connector-specification';
 import { ConnectorFieldsSchema } from '../connector-types/connector-fields-schema';
+import { ConnectorFieldOptions } from '../connector-types/connector-field-options';
+import { ConnectorFieldOptionResponseApiDto } from '../dto/presentation/connector-field-option-response-api.dto';
 import { ConnectorDefinitionResponseApiDto } from '../dto/presentation/connector-definition-response-api.dto';
 import {
   ConnectorSpecificationResponseApiDto,
@@ -64,6 +66,10 @@ export class ConnectorMapper {
     }));
   }
 
+  toFieldOptionsResponse(options: ConnectorFieldOptions): ConnectorFieldOptionResponseApiDto[] {
+    return options.map(option => ({ value: option.value, label: option.label }));
+  }
+
   private mapSpecificationItem(
     item: ConnectorSpecificationItem
   ): ConnectorSpecificationItemResponseApiDto {
@@ -78,6 +84,7 @@ export class ConnectorMapper {
       placeholder: item.placeholder,
       minimum: item.minimum,
       attributes: item.attributes,
+      optionsDependsOn: item.optionsDependsOn,
     };
   }
 
@@ -95,6 +102,7 @@ export class ConnectorMapper {
       placeholder: item.placeholder,
       minimum: item.minimum,
       attributes: item.attributes,
+      optionsDependsOn: item.optionsDependsOn,
       oneOf: item.oneOf?.map(
         (oneOf): ConnectorSpecificationOneOfOptionResponseApiDto => ({
           label: oneOf.label,

--- a/apps/backend/src/data-marts/services/connector/connector-field-options-preview.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-field-options-preview.service.spec.ts
@@ -1,0 +1,199 @@
+const fetchFieldOptionsMock = jest.fn();
+
+jest.mock('@owox/connectors', () => {
+  class AbstractConfig {
+    constructor(configData: Record<string, unknown>) {
+      Object.assign(this, configData);
+    }
+
+    validate() {
+      throw new Error('validate must not be called for a field options preview');
+    }
+  }
+
+  class SourceConfigDto {
+    config: Record<string, unknown>;
+
+    constructor(data: { config: Record<string, unknown> }) {
+      this.config = data.config;
+    }
+  }
+
+  class ConnectorConfigurationException extends Error {}
+
+  class GoogleSheetsSource {
+    constructor(public readonly config: AbstractConfig) {}
+
+    fetchFieldOptions(field: string, signal?: AbortSignal) {
+      return fetchFieldOptionsMock(field, signal);
+    }
+  }
+
+  class OpenHolidaysSource {
+    constructor(public readonly config: AbstractConfig) {}
+  }
+
+  return {
+    Connectors: {
+      GoogleSheets: { GoogleSheetsSource },
+      OpenHolidays: { OpenHolidaysSource },
+    },
+    Core: { AbstractConfig, SourceConfigDto, ConnectorConfigurationException },
+  };
+});
+
+import {
+  BadGatewayException,
+  BadRequestException,
+  ForbiddenException,
+  GatewayTimeoutException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { AuthorizationContext } from '../../../idp';
+import { ConnectorPreviewCredentialsService } from './connector-preview-credentials.service';
+import { ConnectorFieldOptionsPreviewService } from './connector-field-options-preview.service';
+
+describe(ConnectorFieldOptionsPreviewService.name, () => {
+  const context: AuthorizationContext = {
+    projectId: 'project-1',
+    userId: 'user-1',
+    roles: ['editor'],
+  };
+
+  const createService = (
+    inject: jest.Mock = jest
+      .fn()
+      .mockImplementation((_connectorName: string, config: Record<string, unknown>) =>
+        Promise.resolve(config)
+      )
+  ) => {
+    const previewCredentials = { inject } as unknown as ConnectorPreviewCredentialsService;
+
+    return {
+      service: new ConnectorFieldOptionsPreviewService(previewCredentials),
+      previewCredentials,
+    };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns the options resolved by the connector without validating the whole configuration', async () => {
+    const { service, previewCredentials } = createService();
+    fetchFieldOptionsMock.mockResolvedValue([
+      { value: 'Summary', label: 'Summary' },
+      { value: 'Data', label: 'Data' },
+    ]);
+
+    const result = await service.run(context, 'GoogleSheets', 'SheetName', {
+      SpreadsheetId: 'sheet-1',
+    });
+
+    expect(previewCredentials.inject).toHaveBeenCalledWith(
+      'GoogleSheets',
+      { SpreadsheetId: 'sheet-1' },
+      context
+    );
+    expect(fetchFieldOptionsMock).toHaveBeenCalledWith('SheetName', expect.any(AbortSignal));
+    expect(result).toEqual([
+      { value: 'Summary', label: 'Summary' },
+      { value: 'Data', label: 'Data' },
+    ]);
+  });
+
+  it('rejects connectors that do not support dynamic field options', async () => {
+    const { service } = createService();
+
+    await expect(service.run(context, 'OpenHolidays', 'Country', {})).rejects.toThrow(
+      "Connector 'OpenHolidays' does not support dynamic field options"
+    );
+    await expect(service.run(context, 'MissingConnector', 'Country', {})).rejects.toThrow(
+      BadRequestException
+    );
+  });
+
+  it('maps connector configuration failures, such as an unknown field, to Bad Request', async () => {
+    const { service } = createService();
+    const { Core } = jest.requireMock('@owox/connectors') as {
+      Core: { ConnectorConfigurationException: new (message: string) => Error };
+    };
+    fetchFieldOptionsMock.mockRejectedValue(
+      new Core.ConnectorConfigurationException("Field 'Range' does not provide dynamic options")
+    );
+
+    const preview = service.run(context, 'GoogleSheets', 'Range', {});
+    await expect(preview).rejects.toBeInstanceOf(BadRequestException);
+    await expect(preview).rejects.toThrow("Field 'Range' does not provide dynamic options");
+  });
+
+  it('passes credential access failures through unchanged', async () => {
+    const { service } = createService(
+      jest.fn().mockRejectedValue(new ForbiddenException('The selected credentials cannot be used'))
+    );
+
+    await expect(service.run(context, 'GoogleSheets', 'SheetName', {})).rejects.toThrow(
+      ForbiddenException
+    );
+    expect(fetchFieldOptionsMock).not.toHaveBeenCalled();
+  });
+
+  it('does not expose provider authentication failures as an application 401', async () => {
+    const { service } = createService();
+    fetchFieldOptionsMock.mockRejectedValue(
+      Object.assign(new Error('invalid_grant'), { name: 'HttpRequestException', statusCode: 401 })
+    );
+
+    const preview = service.run(context, 'GoogleSheets', 'SheetName', {});
+    await expect(preview).rejects.toBeInstanceOf(BadRequestException);
+    await expect(preview).rejects.toThrow('Connector credentials are invalid or expired');
+  });
+
+  it('maps provider outages to Bad Gateway and unexpected failures to Internal Server Error', async () => {
+    const { service } = createService();
+    fetchFieldOptionsMock.mockRejectedValueOnce(
+      Object.assign(new Error('upstream unavailable'), {
+        name: 'HttpRequestException',
+        statusCode: 503,
+      })
+    );
+    await expect(service.run(context, 'GoogleSheets', 'SheetName', {})).rejects.toThrow(
+      BadGatewayException
+    );
+
+    fetchFieldOptionsMock.mockRejectedValueOnce(new Error('unexpected mapper bug'));
+    await expect(service.run(context, 'GoogleSheets', 'SheetName', {})).rejects.toThrow(
+      InternalServerErrorException
+    );
+  });
+
+  it('rejects malformed connector responses', async () => {
+    const { service } = createService();
+    fetchFieldOptionsMock.mockResolvedValue([{ value: 1 }]);
+
+    await expect(service.run(context, 'GoogleSheets', 'SheetName', {})).rejects.toThrow(
+      InternalServerErrorException
+    );
+  });
+
+  it('bounds the lookup with the backend preview timeout', async () => {
+    jest.useFakeTimers();
+    const { service } = createService();
+    let previewSignal: AbortSignal | undefined;
+    fetchFieldOptionsMock.mockImplementation((_field: string, signal: AbortSignal) => {
+      previewSignal = signal;
+      return new Promise(() => undefined);
+    });
+
+    const preview = service.run(context, 'GoogleSheets', 'SheetName', {});
+    const rejection = expect(preview).rejects.toThrow(GatewayTimeoutException);
+    await jest.advanceTimersByTimeAsync(15_000);
+
+    await rejection;
+    expect(previewSignal?.aborted).toBe(true);
+  });
+});

--- a/apps/backend/src/data-marts/services/connector/connector-field-options-preview.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-field-options-preview.service.ts
@@ -1,0 +1,82 @@
+import {
+  BadRequestException,
+  HttpException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { ConnectorFieldOptions } from '../../connector-types/connector-field-options';
+import { AuthorizationContext } from '../../../idp';
+import { ConnectorPreviewCredentialsService } from './connector-preview-credentials.service';
+import {
+  connectorSourceImplements,
+  createConnectorPreviewSource,
+  mapConnectorPreviewError,
+  withConnectorPreviewTimeout,
+} from './connector-preview-support';
+
+const PREVIEW_ERROR_MESSAGES = {
+  timeout: 'Connector field options preview timed out',
+  unexpected: 'Unable to preview connector field options',
+};
+
+/**
+ * Resolves the allowed values of a configuration field declared with the
+ * DYNAMIC_OPTIONS attribute (for example the sheet tabs of a spreadsheet).
+ *
+ * Unlike the fields preview, the whole configuration is not validated up
+ * front: the caller is still filling the form, so only the fields the source
+ * needs for this lookup are expected to be present. The source reports what is
+ * missing through a configuration error.
+ */
+@Injectable()
+export class ConnectorFieldOptionsPreviewService {
+  private readonly logger = new Logger(ConnectorFieldOptionsPreviewService.name);
+
+  constructor(private readonly previewCredentials: ConnectorPreviewCredentialsService) {}
+
+  async run(
+    context: AuthorizationContext,
+    connectorName: string,
+    field: string,
+    configuration: Record<string, unknown>
+  ): Promise<ConnectorFieldOptions> {
+    if (!connectorSourceImplements(connectorName, 'fetchFieldOptions')) {
+      throw new BadRequestException(
+        `Connector '${connectorName}' does not support dynamic field options`
+      );
+    }
+
+    let configWithCredentials: Record<string, unknown>;
+    try {
+      configWithCredentials = await this.previewCredentials.inject(
+        connectorName,
+        configuration,
+        context
+      );
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      this.logger.error(
+        `Failed to resolve credentials for ${connectorName} field options preview`,
+        error
+      );
+      throw new InternalServerErrorException(
+        'Unable to resolve credentials for field options preview'
+      );
+    }
+
+    const source = createConnectorPreviewSource(connectorName, configWithCredentials, this.logger);
+
+    try {
+      const options = await withConnectorPreviewTimeout(
+        signal => source.fetchFieldOptions(field, signal),
+        PREVIEW_ERROR_MESSAGES.timeout
+      );
+      return ConnectorFieldOptions.parse(options);
+    } catch (error) {
+      throw mapConnectorPreviewError(error, this.logger, PREVIEW_ERROR_MESSAGES);
+    }
+  }
+}

--- a/apps/backend/src/data-marts/services/connector/connector-fields-preview.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-fields-preview.service.ts
@@ -1,15 +1,10 @@
 import {
-  BadGatewayException,
   BadRequestException,
-  ForbiddenException,
-  GatewayTimeoutException,
   HttpException,
   Injectable,
   InternalServerErrorException,
   Logger,
 } from '@nestjs/common';
-// @ts-expect-error - Package lacks TypeScript declarations
-import { Connectors, Core } from '@owox/connectors';
 import { ConnectorFieldsSchema } from '../../connector-types/connector-fields-schema';
 import { AuthorizationContext } from '../../../idp';
 import { ConnectorPreviewCredentialsService } from './connector-preview-credentials.service';
@@ -17,35 +12,17 @@ import {
   mapConnectorFieldsSchema,
   type SourceFieldsSchema,
 } from './connector-fields-schema.mapper';
+import {
+  connectorSourceImplements,
+  createConnectorPreviewSource,
+  mapConnectorPreviewError,
+  withConnectorPreviewTimeout,
+} from './connector-preview-support';
 
-const PREVIEW_TIMEOUT_MS = 15_000;
-
-class PreviewTimeoutError extends Error {}
-
-class ConnectorFieldsPreviewConfig extends Core.AbstractConfig {
-  private readonly logger: Logger;
-
-  constructor(configData: Record<string, unknown>, logger: Logger) {
-    super(configData);
-    this.logger = logger;
-  }
-
-  handleStatusUpdate(): void {}
-
-  updateLastImportDate(): void {}
-
-  updateLastRequstedDate(): void {}
-
-  isInProgress(): boolean {
-    return false;
-  }
-
-  addWarningToCurrentStatus(): void {}
-
-  logMessage(message: string): void {
-    this.logger.debug(message);
-  }
-}
+const PREVIEW_ERROR_MESSAGES = {
+  timeout: 'Connector field preview timed out',
+  unexpected: 'Unable to preview connector fields',
+};
 
 @Injectable()
 export class ConnectorFieldsPreviewService {
@@ -58,8 +35,7 @@ export class ConnectorFieldsPreviewService {
     connectorName: string,
     configuration: Record<string, unknown>
   ): Promise<ConnectorFieldsSchema> {
-    const SourceClass = Connectors[connectorName]?.[`${connectorName}Source`];
-    if (typeof SourceClass?.prototype?.fetchFieldsSchema !== 'function') {
+    if (!connectorSourceImplements(connectorName, 'fetchFieldsSchema')) {
       throw new BadRequestException(
         `Connector '${connectorName}' does not support dynamic field preview`
       );
@@ -80,7 +56,7 @@ export class ConnectorFieldsPreviewService {
       throw new InternalServerErrorException('Unable to resolve credentials for field preview');
     }
 
-    const source = this.createSource(connectorName, configWithCredentials);
+    const source = createConnectorPreviewSource(connectorName, configWithCredentials, this.logger);
 
     try {
       source.config.validate();
@@ -90,143 +66,13 @@ export class ConnectorFieldsPreviewService {
     }
 
     try {
-      const sourceFieldsSchema = (await this.withTimeout(signal =>
-        source.fetchFieldsSchema(signal)
+      const sourceFieldsSchema = (await withConnectorPreviewTimeout(
+        signal => source.fetchFieldsSchema(signal),
+        PREVIEW_ERROR_MESSAGES.timeout
       )) as SourceFieldsSchema;
       return ConnectorFieldsSchema.parse(mapConnectorFieldsSchema(sourceFieldsSchema));
     } catch (error) {
-      throw this.mapPreviewError(error);
+      throw mapConnectorPreviewError(error, this.logger, PREVIEW_ERROR_MESSAGES);
     }
-  }
-
-  private createSource(connectorName: string, configuration: Record<string, unknown>) {
-    const SourceClass = Connectors[connectorName][`${connectorName}Source`];
-    const sourceConfig = new Core.SourceConfigDto({
-      name: connectorName,
-      config: configuration,
-    });
-
-    return new SourceClass(new ConnectorFieldsPreviewConfig(sourceConfig.config, this.logger));
-  }
-
-  private async withTimeout<T>(work: (signal: AbortSignal) => Promise<T>): Promise<T> {
-    const abortController = new AbortController();
-    let timeout: NodeJS.Timeout | undefined;
-    const deadline = new Promise<never>((_resolve, reject) => {
-      timeout = setTimeout(() => {
-        abortController.abort();
-        reject(new PreviewTimeoutError('Connector field preview timed out'));
-      }, PREVIEW_TIMEOUT_MS);
-    });
-
-    try {
-      return await Promise.race([work(abortController.signal), deadline]);
-    } catch (error) {
-      if (abortController.signal.aborted) {
-        throw new PreviewTimeoutError('Connector field preview timed out');
-      }
-      throw error;
-    } finally {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-    }
-  }
-
-  private mapPreviewError(error: unknown): HttpException {
-    if (error instanceof HttpException) {
-      return error;
-    }
-    if (error instanceof PreviewTimeoutError) {
-      return new GatewayTimeoutException('Connector field preview timed out');
-    }
-
-    const status = this.extractProviderStatus(error);
-    const message = error instanceof Error ? error.message : String(error);
-    const normalizedMessage = message.toLowerCase();
-
-    if (status === 401 || this.looksLikeAuthenticationFailure(normalizedMessage)) {
-      // The application client reserves HTTP 401 for the OWOX login session.
-      return new BadRequestException('Connector credentials are invalid or expired');
-    }
-    if (status === 403) {
-      return new ForbiddenException(message);
-    }
-    if (
-      status === 400 ||
-      status === 404 ||
-      this.isConnectorConfigurationError(error) ||
-      this.looksLikeConfigurationFailure(normalizedMessage)
-    ) {
-      return new BadRequestException({ message });
-    }
-    if (
-      status === 429 ||
-      (status !== undefined && status >= 500) ||
-      this.isProviderRequestError(error)
-    ) {
-      return new BadGatewayException('Connector provider is temporarily unavailable');
-    }
-
-    this.logger.error('Unexpected connector field preview failure', error);
-    return new InternalServerErrorException('Unable to preview connector fields');
-  }
-
-  private extractProviderStatus(error: unknown): number | undefined {
-    if (!error || typeof error !== 'object') {
-      return undefined;
-    }
-
-    const record = error as Record<string, unknown>;
-    for (const value of [record.statusCode, record.status]) {
-      if (typeof value === 'number') {
-        return value;
-      }
-    }
-
-    if (record.response && typeof record.response === 'object') {
-      const responseStatus = (record.response as Record<string, unknown>).status;
-      if (typeof responseStatus === 'number') {
-        return responseStatus;
-      }
-    }
-
-    return this.extractProviderStatus(record.cause);
-  }
-
-  private isProviderRequestError(error: unknown): boolean {
-    return error instanceof Error && error.name === 'HttpRequestException';
-  }
-
-  private isConnectorConfigurationError(error: unknown): boolean {
-    if (error instanceof Core.ConnectorConfigurationException) {
-      return true;
-    }
-    if (!error || typeof error !== 'object') {
-      return false;
-    }
-    return this.isConnectorConfigurationError((error as Record<string, unknown>).cause);
-  }
-
-  private looksLikeAuthenticationFailure(message: string): boolean {
-    return [
-      'access token',
-      'authentication failed',
-      'failed to get access token',
-      'invalid credential',
-      'invalid_grant',
-      'token error',
-    ].some(fragment => message.includes(fragment));
-  }
-
-  private looksLikeConfigurationFailure(message: string): boolean {
-    return [
-      'no headers found',
-      'no columns selected',
-      'header row',
-      'spreadsheet not found',
-      'sheet not found',
-      'unsupported google sheets authentication type',
-    ].some(fragment => message.includes(fragment));
   }
 }

--- a/apps/backend/src/data-marts/services/connector/connector-preview-support.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-preview-support.ts
@@ -1,0 +1,204 @@
+import {
+  BadGatewayException,
+  BadRequestException,
+  ForbiddenException,
+  GatewayTimeoutException,
+  HttpException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+// @ts-expect-error - Package lacks TypeScript declarations
+import { Connectors, Core } from '@owox/connectors';
+
+/**
+ * Shared building blocks for configuration-time connector previews (dynamic
+ * fields, dynamic field options): an inert connector config, in-process source
+ * creation, a bounded timeout, and provider error → HTTP error mapping.
+ */
+
+export const CONNECTOR_PREVIEW_TIMEOUT_MS = 15_000;
+
+export class ConnectorPreviewTimeoutError extends Error {}
+
+export interface ConnectorPreviewErrorMessages {
+  timeout: string;
+  unexpected: string;
+}
+
+/**
+ * Connector config that never touches persistence or run state: previews run
+ * in-process and must leave no trace in the data mart.
+ */
+export class ConnectorPreviewConfig extends Core.AbstractConfig {
+  private readonly logger: Logger;
+
+  constructor(configData: Record<string, unknown>, logger: Logger) {
+    super(configData);
+    this.logger = logger;
+  }
+
+  handleStatusUpdate(): void {}
+
+  updateLastImportDate(): void {}
+
+  updateLastRequstedDate(): void {}
+
+  isInProgress(): boolean {
+    return false;
+  }
+
+  addWarningToCurrentStatus(): void {}
+
+  logMessage(message: string): void {
+    this.logger.debug(message);
+  }
+}
+
+export function getConnectorSourceClass(connectorName: string): unknown {
+  return Connectors[connectorName]?.[`${connectorName}Source`];
+}
+
+export function connectorSourceImplements(connectorName: string, method: string): boolean {
+  const SourceClass = getConnectorSourceClass(connectorName) as
+    | { prototype?: Record<string, unknown> }
+    | undefined;
+  return typeof SourceClass?.prototype?.[method] === 'function';
+}
+
+export function createConnectorPreviewSource(
+  connectorName: string,
+  configuration: Record<string, unknown>,
+  logger: Logger
+) {
+  const SourceClass = Connectors[connectorName][`${connectorName}Source`];
+  const sourceConfig = new Core.SourceConfigDto({
+    name: connectorName,
+    config: configuration,
+  });
+
+  return new SourceClass(new ConnectorPreviewConfig(sourceConfig.config, logger));
+}
+
+export async function withConnectorPreviewTimeout<T>(
+  work: (signal: AbortSignal) => Promise<T>,
+  timeoutMessage: string
+): Promise<T> {
+  const abortController = new AbortController();
+  let timeout: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      abortController.abort();
+      reject(new ConnectorPreviewTimeoutError(timeoutMessage));
+    }, CONNECTOR_PREVIEW_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([work(abortController.signal), deadline]);
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      throw new ConnectorPreviewTimeoutError(timeoutMessage);
+    }
+    throw error;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function mapConnectorPreviewError(
+  error: unknown,
+  logger: Logger,
+  messages: ConnectorPreviewErrorMessages
+): HttpException {
+  if (error instanceof HttpException) {
+    return error;
+  }
+  if (error instanceof ConnectorPreviewTimeoutError) {
+    return new GatewayTimeoutException(messages.timeout);
+  }
+
+  const status = extractProviderStatus(error);
+  const message = error instanceof Error ? error.message : String(error);
+  const normalizedMessage = message.toLowerCase();
+
+  if (status === 401 || looksLikeAuthenticationFailure(normalizedMessage)) {
+    // The application client reserves HTTP 401 for the OWOX login session.
+    return new BadRequestException('Connector credentials are invalid or expired');
+  }
+  if (status === 403) {
+    return new ForbiddenException(message);
+  }
+  if (
+    status === 400 ||
+    status === 404 ||
+    isConnectorConfigurationError(error) ||
+    looksLikeConfigurationFailure(normalizedMessage)
+  ) {
+    return new BadRequestException({ message });
+  }
+  if (status === 429 || (status !== undefined && status >= 500) || isProviderRequestError(error)) {
+    return new BadGatewayException('Connector provider is temporarily unavailable');
+  }
+
+  logger.error(messages.unexpected, error);
+  return new InternalServerErrorException(messages.unexpected);
+}
+
+function extractProviderStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const record = error as Record<string, unknown>;
+  for (const value of [record.statusCode, record.status]) {
+    if (typeof value === 'number') {
+      return value;
+    }
+  }
+
+  if (record.response && typeof record.response === 'object') {
+    const responseStatus = (record.response as Record<string, unknown>).status;
+    if (typeof responseStatus === 'number') {
+      return responseStatus;
+    }
+  }
+
+  return extractProviderStatus(record.cause);
+}
+
+function isProviderRequestError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'HttpRequestException';
+}
+
+function isConnectorConfigurationError(error: unknown): boolean {
+  if (error instanceof Core.ConnectorConfigurationException) {
+    return true;
+  }
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  return isConnectorConfigurationError((error as Record<string, unknown>).cause);
+}
+
+function looksLikeAuthenticationFailure(message: string): boolean {
+  return [
+    'access token',
+    'authentication failed',
+    'failed to get access token',
+    'invalid credential',
+    'invalid_grant',
+    'token error',
+  ].some(fragment => message.includes(fragment));
+}
+
+function looksLikeConfigurationFailure(message: string): boolean {
+  return [
+    'no headers found',
+    'no columns selected',
+    'header row',
+    'spreadsheet not found',
+    'sheet not found',
+    'unsupported google sheets authentication type',
+  ].some(fragment => message.includes(fragment));
+}

--- a/apps/backend/src/data-marts/services/connector/connector.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector.service.ts
@@ -37,6 +37,7 @@ interface ConnectorConfigField {
   placeholder?: string;
   minimum?: number;
   attributes?: Core.CONFIG_ATTRIBUTES[];
+  optionsDependsOn?: string[];
   oneOf?: ConnectorSpecificationOneOf[];
 }
 
@@ -465,6 +466,7 @@ export class ConnectorService {
         placeholder: config[key].placeholder,
         minimum: config[key].minimum,
         attributes: config[key].attributes,
+        optionsDependsOn: config[key].optionsDependsOn,
         oneOf: config[key].oneOf?.map(oneOf => {
           return {
             label: oneOf.label,
@@ -485,6 +487,7 @@ export class ConnectorService {
                   placeholder: itemValue.placeholder,
                   minimum: itemValue.minimum,
                   attributes: itemValue.attributes,
+                  optionsDependsOn: itemValue.optionsDependsOn,
                 };
                 return acc;
               },

--- a/apps/backend/test/connector-fields.e2e-spec.ts
+++ b/apps/backend/test/connector-fields.e2e-spec.ts
@@ -119,6 +119,73 @@ describe('Connector Fields (e2e)', () => {
     });
   });
 
+  describe('Dynamic field options preview', () => {
+    it('POST /api/connectors/GoogleSheets/options/preview - requires the field name', async () => {
+      const res = await agent
+        .post('/api/connectors/GoogleSheets/options/preview')
+        .send({ configuration: {} })
+        .set(AUTH_HEADER);
+
+      expect(res.status).toBe(400);
+      expect(res.body.statusCode).toBe(400);
+    });
+
+    it('POST /api/connectors/GoogleSheets/options/preview - reports the missing spreadsheet instead of validating the whole form', async () => {
+      const res = await agent
+        .post('/api/connectors/GoogleSheets/options/preview')
+        .send({ field: 'SheetName', configuration: {} })
+        .set(AUTH_HEADER);
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('Spreadsheet ID or URL is required');
+    });
+
+    it('POST /api/connectors/GoogleSheets/options/preview - rejects fields without dynamic options', async () => {
+      const res = await agent
+        .post('/api/connectors/GoogleSheets/options/preview')
+        .send({ field: 'Range', configuration: { SpreadsheetId: 'sheet-id' } })
+        .set(AUTH_HEADER);
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain("Field 'Range' does not provide dynamic options");
+    });
+
+    it('POST /api/connectors/OpenHolidays/options/preview - rejects connectors without dynamic options', async () => {
+      const res = await agent
+        .post('/api/connectors/OpenHolidays/options/preview')
+        .send({ field: 'Country', configuration: {} })
+        .set(AUTH_HEADER);
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('does not support dynamic field options');
+    });
+
+    it('POST /api/connectors/GoogleSheets/options/preview - rejects another connector credential', async () => {
+      const credentialsService = app.get(ConnectorSourceCredentialsService);
+      const credential = await credentialsService.createCredentials(
+        '0',
+        '0',
+        'GoogleAds',
+        { access_token: 'not-a-google-sheets-token' },
+        null
+      );
+
+      const res = await agent
+        .post('/api/connectors/GoogleSheets/options/preview')
+        .send({
+          field: 'SheetName',
+          configuration: {
+            AuthType: { oauth2: { _source_credential_id: credential.id } },
+            SpreadsheetId: 'sheet-id',
+          },
+        })
+        .set(AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).toBe('The selected credentials cannot be used for this preview');
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // CAPI-10: All connectors have well-formed fields schemas
   // ---------------------------------------------------------------------------

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import { MemoryRouter } from 'react-router';
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ConfigurationStep } from './ConfigurationStep';
 import type { ConnectorSpecificationResponseApiDto } from '../../../../shared/api';
-import { RequiredType } from '../../../../shared/api';
+import { ConnectorApiService, RequiredType } from '../../../../shared/api';
 
 vi.mock(
   '../../../../../data-marts/edit/components/DataMartDefinitionSettings/form/CopyConfigurationButton',
@@ -271,5 +271,301 @@ describe('ConfigurationStep Google Sheets OAuth fields', () => {
     expect(await screen.findByRole('textbox', { name: 'Spreadsheet ID or URL *' })).toHaveValue(
       spreadsheetUrl
     );
+  });
+});
+
+describe('ConfigurationStep Google Sheets OAuth spreadsheet input visibility', () => {
+  const oauthOnlySpecification: ConnectorSpecificationResponseApiDto[] = [
+    {
+      name: 'AuthType',
+      title: 'Auth Type',
+      requiredType: RequiredType.OBJECT,
+      required: true,
+      oneOf: [
+        {
+          label: 'OAuth2',
+          value: 'oauth2',
+          requiredType: RequiredType.OBJECT,
+          attributes: ['OAUTH_FLOW'],
+          items: {
+            RefreshToken: {
+              name: 'RefreshToken',
+              title: 'Refresh Token',
+              requiredType: RequiredType.STRING,
+              required: true,
+            },
+          },
+        },
+      ],
+    },
+    {
+      name: 'SpreadsheetId',
+      title: 'Spreadsheet ID or URL',
+      requiredType: RequiredType.STRING,
+      required: true,
+    },
+    {
+      name: 'SheetName',
+      title: 'Sheet Name',
+      requiredType: RequiredType.STRING,
+      required: true,
+    },
+  ];
+
+  it('never shows the spreadsheet input under OAuth before sign-in, only once manual OAuth is chosen', async () => {
+    let resolveSettings!: (value: unknown) => void;
+    oauthMocks.getSettings.mockReturnValue(
+      new Promise(resolve => {
+        resolveSettings = resolve;
+      })
+    );
+    oauthMocks.checkStatus.mockResolvedValue({ valid: false });
+
+    render(
+      <MemoryRouter>
+        <ConfigurationStep
+          connector={googleSheetsConnector}
+          connectorSpecification={oauthOnlySpecification}
+          initialConfiguration={{ AuthType: { oauth2: {} } }}
+        />
+      </MemoryRouter>
+    );
+
+    // Settings are still loading: the picker-driven field must not flash.
+    expect(await screen.findByRole('textbox', { name: 'Sheet Name *' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', { name: 'Spreadsheet ID or URL *' })
+    ).not.toBeInTheDocument();
+
+    resolveSettings({
+      isEnabled: true,
+      vars: {
+        ClientId: 'client-id',
+        RedirectUri: 'https://app.example.com/oauth/google-sheets/callback',
+        PickerApiKey: 'picker-key',
+        ProjectNumber: '123456789',
+      },
+    });
+
+    // Signed out with managed OAuth: still hidden, the spreadsheet comes from Google Picker.
+    expect(await screen.findByRole('button', { name: 'Manually' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', { name: 'Spreadsheet ID or URL *' })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Manually' }));
+
+    expect(
+      await screen.findByRole('textbox', { name: 'Spreadsheet ID or URL *' })
+    ).toBeInTheDocument();
+  });
+});
+
+describe('ConfigurationStep dynamic field options', () => {
+  const dynamicSpecification: ConnectorSpecificationResponseApiDto[] = [
+    {
+      name: 'SpreadsheetId',
+      title: 'Spreadsheet ID or URL',
+      requiredType: RequiredType.STRING,
+      required: true,
+    },
+    {
+      name: 'SheetName',
+      title: 'Sheet Name',
+      requiredType: RequiredType.STRING,
+      required: true,
+      attributes: ['DYNAMIC_OPTIONS'],
+      optionsDependsOn: ['SpreadsheetId'],
+    },
+  ];
+  const sheets = [
+    { value: 'Summary', label: 'Summary' },
+    { value: 'Data', label: 'Data' },
+  ];
+
+  function DynamicHarness({
+    initial,
+    onChange,
+  }: {
+    initial: Record<string, unknown>;
+    onChange: (configuration: Record<string, unknown>) => void;
+  }) {
+    const [configuration, setConfiguration] = useState<Record<string, unknown>>(initial);
+    return (
+      <ConfigurationStep
+        connector={googleSheetsConnector}
+        connectorSpecification={dynamicSpecification}
+        initialConfiguration={configuration}
+        onConfigurationChange={next => {
+          setConfiguration(next);
+          onChange(next);
+        }}
+      />
+    );
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('loads the sheet tabs once the spreadsheet is known', async () => {
+    const previewSpy = vi
+      .spyOn(ConnectorApiService.prototype, 'previewConnectorFieldOptions')
+      .mockResolvedValue(sheets);
+    const onChange = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <DynamicHarness initial={{}} onChange={onChange} />
+      </MemoryRouter>
+    );
+
+    const combobox = await screen.findByRole('combobox', { name: 'Sheet Name' });
+    expect(combobox).toBeDisabled();
+    expect(combobox).toHaveTextContent('Fill the fields above to load sheet names');
+    expect(previewSpy).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Spreadsheet ID or URL *' }), {
+      target: { value: 'sheet-1' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: 'Sheet Name' })).toBeEnabled();
+    });
+    expect(previewSpy).toHaveBeenCalledWith(
+      'GoogleSheets',
+      'SheetName',
+      expect.objectContaining({ SpreadsheetId: 'sheet-1' }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('clears a sheet name that no longer exists in the loaded tabs', async () => {
+    vi.spyOn(ConnectorApiService.prototype, 'previewConnectorFieldOptions').mockResolvedValue(
+      sheets
+    );
+    const onChange = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <DynamicHarness
+          initial={{ SpreadsheetId: 'sheet-1', SheetName: 'Old tab' }}
+          onChange={onChange}
+        />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ SheetName: '' }));
+    });
+  });
+
+  it('falls back to a text input when the tabs cannot be loaded', async () => {
+    vi.spyOn(ConnectorApiService.prototype, 'previewConnectorFieldOptions').mockRejectedValue(
+      new Error('Google Sheets access denied')
+    );
+    const onChange = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <DynamicHarness initial={{ SpreadsheetId: 'sheet-1' }} onChange={onChange} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('textbox', { name: 'Sheet Name *' })).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('Google Sheets access denied');
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Sheet Name *' }), {
+      target: { value: 'Typed tab' },
+    });
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ SheetName: 'Typed tab' }));
+    });
+  });
+});
+
+describe('ConfigurationStep first open of a Google Sheets OAuth configuration', () => {
+  const freshSpecification: ConnectorSpecificationResponseApiDto[] = [
+    {
+      name: 'AuthType',
+      title: 'Auth Type',
+      requiredType: RequiredType.OBJECT,
+      required: true,
+      oneOf: [
+        {
+          label: 'OAuth2',
+          value: 'oauth2',
+          requiredType: RequiredType.OBJECT,
+          attributes: ['OAUTH_FLOW'],
+          items: {
+            RefreshToken: {
+              name: 'RefreshToken',
+              title: 'Refresh Token',
+              requiredType: RequiredType.STRING,
+              required: true,
+            },
+          },
+        },
+        {
+          label: 'Service Account',
+          value: 'service_account',
+          requiredType: RequiredType.OBJECT,
+          items: {
+            ServiceAccountKey: {
+              name: 'ServiceAccountKey',
+              title: 'Service Account Key',
+              requiredType: RequiredType.STRING,
+              required: true,
+              attributes: ['SECRET'],
+            },
+          },
+        },
+      ],
+    },
+    {
+      name: 'SpreadsheetId',
+      title: 'Spreadsheet ID or URL',
+      requiredType: RequiredType.STRING,
+      required: true,
+    },
+  ];
+
+  it('keeps the spreadsheet input hidden on a brand-new configuration', async () => {
+    oauthMocks.getSettings.mockResolvedValue({
+      isEnabled: true,
+      vars: {
+        ClientId: 'client-id',
+        RedirectUri: 'https://app.example.com/oauth/google-sheets/callback',
+        PickerApiKey: 'picker-key',
+        ProjectNumber: '123456789',
+      },
+    });
+    oauthMocks.checkStatus.mockResolvedValue({ valid: false });
+    const onConfigurationChange = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <ConfigurationStep
+          connector={googleSheetsConnector}
+          connectorSpecification={freshSpecification}
+          initialConfiguration={{}}
+          onConfigurationChange={onConfigurationChange}
+        />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('button', { name: 'Sign in with Google' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', { name: 'Spreadsheet ID or URL *' })
+    ).not.toBeInTheDocument();
+    // Seeded defaults are not reported as a user change; the first real edit is.
+    expect(onConfigurationChange).not.toHaveBeenCalled();
+
+    // Radix tabs switch on pointer down, not on click.
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Service Account' }));
+
+    expect(
+      await screen.findByRole('textbox', { name: 'Spreadsheet ID or URL *' })
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.tsx
@@ -93,7 +93,7 @@ export function ConfigurationStep({
   // own echo and distinguishes it from a genuine outside change.
   const lastEchoedConfigRef = useRef<Record<string, unknown> | null>(null);
   const [secretEditing, setSecretEditing] = useState<Record<string, boolean>>({});
-  const [managedOAuthModes, setManagedOAuthModes] = useState<Record<string, boolean>>({});
+  const [managedOAuthModes, setManagedOAuthModes] = useState<Partial<Record<string, boolean>>>({});
 
   useEffect(() => {
     trackEvent({
@@ -123,6 +123,15 @@ export function ConfigurationStep({
 
         if (config[spec.name] === undefined && spec.default !== undefined) {
           config[spec.name] = spec.default;
+        }
+
+        // Seed the first option of a oneOf field here as well. The oneOf renderer
+        // does the same in its mount effect, but that write lands before this
+        // seeding replaces the state and is lost, leaving the field unset until
+        // the user touches it.
+        const firstOption = spec.oneOf?.[0]?.value;
+        if (config[spec.name] === undefined && firstOption) {
+          config[spec.name] = { [firstOption]: {} };
         }
 
         if (isEditingExisting && isSecret) {
@@ -346,10 +355,16 @@ export function ConfigurationStep({
   const selectedAuthType = isRecord(configuration.AuthType)
     ? Object.keys(configuration.AuthType)[0]
     : undefined;
+  // Under OAuth the spreadsheet is chosen with Google Picker, so the manual
+  // input stays hidden until the OAuth renderer explicitly reports manual mode
+  // (settings still loading or not yet signed in must not flash the input).
+  // The renderer only mounts on the OAuth tab, so an explicit "managed" report
+  // is trusted even before the AuthType value itself is reflected in the state.
+  const managedAuthTypeMode = managedOAuthModes.AuthType;
   const usesManagedGoogleSheetsOAuth =
     connector.name === GOOGLE_SHEETS_CONNECTOR_NAME &&
-    selectedAuthType === 'oauth2' &&
-    managedOAuthModes.AuthType;
+    (managedAuthTypeMode === true ||
+      (selectedAuthType === 'oauth2' && managedAuthTypeMode !== false));
   const visibleSpecifications = usesManagedGoogleSheetsOAuth
     ? sortedSpecifications.filter(spec => spec.name !== 'SpreadsheetId')
     : sortedSpecifications;

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationField/ConfigurationDynamicOptionsField.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationField/ConfigurationDynamicOptionsField.tsx
@@ -1,0 +1,115 @@
+import { useEffect } from 'react';
+import { Input } from '@owox/ui/components/input';
+import { Button } from '@owox/ui/components/button';
+import type { ConnectorSpecificationResponseApiDto } from '../../../../../../shared/api/types';
+import { Combobox } from '../../../../../../../../shared/components/Combobox/combobox.tsx';
+import { useConnectorFieldOptions } from '../../../../../../shared/model/hooks/useConnectorFieldOptions';
+
+interface ConfigurationDynamicOptionsFieldProps {
+  specification: ConnectorSpecificationResponseApiDto;
+  configuration: Record<string, unknown>;
+  onValueChange: (name: string, value: unknown) => void;
+  connectorName: string;
+}
+
+/**
+ * Field whose allowed values come from the source (DYNAMIC_OPTIONS): waits for
+ * its dependencies, loads the options, and falls back to free-text input when
+ * the options cannot be loaded so the user is never blocked.
+ */
+export function ConfigurationDynamicOptionsField({
+  specification,
+  configuration,
+  onValueChange,
+  connectorName,
+}: ConfigurationDynamicOptionsFieldProps) {
+  const { name, placeholder, optionsDependsOn } = specification;
+  const displayName = (specification.title ?? specification.name).toLowerCase();
+  const rawValue = configuration[name];
+  const currentValue = typeof rawValue === 'string' ? rawValue : '';
+
+  const { status, options, error, loadedKey, reload } = useConnectorFieldOptions({
+    connectorName,
+    field: name,
+    configuration,
+    dependsOn: optionsDependsOn,
+  });
+
+  // A value that is not among the freshly loaded options belongs to a previous
+  // spreadsheet or a renamed tab; clearing it makes the user pick a valid one
+  // instead of failing later at the fields preview.
+  useEffect(() => {
+    if (status !== 'loaded' || options.length === 0 || currentValue === '') return;
+    if (options.some(option => option.value === currentValue)) return;
+    onValueChange(name, '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, loadedKey]);
+
+  if (status === 'error') {
+    return (
+      <div className='space-y-2'>
+        <Input
+          id={name}
+          name={name}
+          type='text'
+          value={currentValue}
+          placeholder={placeholder ?? `Enter ${displayName}`}
+          onChange={event => {
+            onValueChange(name, event.target.value);
+          }}
+        />
+        <div role='alert' className='text-destructive flex items-center gap-2 text-sm'>
+          <span className='min-w-0 flex-1'>
+            Could not load the list of {displayName}s: {error ?? 'unknown error'}. Enter the value
+            manually or retry.
+          </span>
+          <Button type='button' variant='ghost' size='sm' onClick={reload}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'loaded' && options.length === 0) {
+    return (
+      <div className='space-y-2'>
+        <Input
+          id={name}
+          name={name}
+          type='text'
+          value={currentValue}
+          placeholder={placeholder ?? `Enter ${displayName}`}
+          onChange={event => {
+            onValueChange(name, event.target.value);
+          }}
+        />
+        <p className='text-muted-foreground text-sm'>No {displayName}s were found.</p>
+      </div>
+    );
+  }
+
+  const isWaiting = status === 'waiting';
+  const isLoading = status === 'loading';
+
+  return (
+    <Combobox
+      options={options}
+      value={currentValue}
+      onValueChange={(value: string) => {
+        onValueChange(name, value);
+      }}
+      placeholder={
+        isWaiting
+          ? `Fill the fields above to load ${displayName}s`
+          : isLoading
+            ? `Loading ${displayName}s...`
+            : (placeholder ?? `Select ${displayName}`)
+      }
+      emptyMessage={`No ${displayName}s found`}
+      disabled={isWaiting || isLoading}
+      ariaLabel={specification.title ?? specification.name}
+      className='w-full'
+    />
+  );
+}

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationField/index.ts
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationField/index.ts
@@ -6,8 +6,10 @@ import { ConfigurationStringField } from './ConfigurationStringField';
 import { ConfigurationObjectField } from './ConfigurationObjectField';
 import { ConfigurationSecretField } from './ConfigurationSecretField';
 import { ConfigurationComboboxField } from './ConfigurationComboboxField';
+import { ConfigurationDynamicOptionsField } from './ConfigurationDynamicOptionsField';
 
 export {
+  ConfigurationDynamicOptionsField,
   ConfigurationBooleanField,
   ConfigurationNumberField,
   ConfigurationArrayField,

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationFieldRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationFieldRender.tsx
@@ -9,8 +9,10 @@ import {
   ConfigurationObjectField,
   ConfigurationDateField,
   ConfigurationStringField,
+  ConfigurationDynamicOptionsField,
 } from './ConfigurationField';
 import { OauthRenderFactory } from './Oauth/OauthRenderFactory';
+import { hasDynamicOptions } from '../../../../../shared/utils/dynamic-options.utils';
 
 interface ConfigurationStepFieldRenderProps {
   specification: ConnectorSpecificationResponseApiDto;
@@ -53,6 +55,17 @@ export function configurationFieldRender({
         onValueChange={onValueChange}
         isEditingExisting={isEditingExisting}
         isSecretEditing={isSecretEditing}
+      />
+    );
+  }
+
+  if (hasDynamicOptions(specification)) {
+    return (
+      <ConfigurationDynamicOptionsField
+        specification={specification}
+        configuration={configuration}
+        onValueChange={onValueChange}
+        connectorName={connectorName}
       />
     );
   }

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
@@ -58,6 +58,7 @@ export function OauthRenderFactory({
   const [fieldSecretEditing, setFieldSecretEditing] = useState<Record<string, boolean>>({});
   const [status, setStatus] = useState<OAuthStatusResponseDto | null>(null);
   const [settings, setSettings] = useState<OAuthSettingsResponseDto | null>(null);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const credentialId = useMemo(() => {
@@ -237,16 +238,39 @@ export function OauthRenderFactory({
       } catch (error) {
         console.error('Failed to fetch settings:', error);
         setSettings(null);
+      } finally {
+        setSettingsLoaded(true);
       }
     };
     void fetchSettings();
   }, [connectorName, fieldPath, getSettings]);
 
   const isOAuthEnabled = Boolean(settings?.isEnabled);
+  const isSettingsLoading = !settingsLoaded;
 
   useEffect(() => {
-    onManagedModeChange?.(!isManualMode && isOAuthEnabled);
-  }, [isManualMode, isOAuthEnabled, onManagedModeChange]);
+    // While the settings are unknown, assume the managed flow: the manual
+    // fields (and any picker-driven fields hidden by managed mode) must not
+    // flash before the answer arrives.
+    onManagedModeChange?.(!isManualMode && (isSettingsLoading || isOAuthEnabled));
+  }, [isManualMode, isOAuthEnabled, isSettingsLoading, onManagedModeChange]);
+
+  useEffect(
+    () => () => {
+      // The renderer lives only on the OAuth option's tab: once it unmounts
+      // (another option was selected) the managed flow no longer applies.
+      onManagedModeChange?.(false);
+    },
+    [onManagedModeChange]
+  );
+
+  if (isSettingsLoading && !isManualMode) {
+    return (
+      <div className='text-muted-foreground mt-2 mb-2 text-sm' role='status'>
+        Loading sign-in options...
+      </div>
+    );
+  }
 
   if ((isManualMode || !isOAuthEnabled) && option?.items) {
     return (

--- a/apps/web/src/features/connectors/shared/api/connector-api.service.ts
+++ b/apps/web/src/features/connectors/shared/api/connector-api.service.ts
@@ -4,6 +4,7 @@ import type {
   ConnectorDefinitionDto,
   ConnectorSpecificationResponseApiDto,
   ConnectorFieldsResponseApiDto,
+  ConnectorFieldOptionResponseApiDto,
   OAuthCallbackResponseDto,
   OAuthStatusResponseDto,
   OAuthSettingsResponseDto,
@@ -36,6 +37,22 @@ export class ConnectorApiService extends ApiService {
     return this.post<ConnectorFieldsResponseApiDto[]>(
       `/${connectorName}/fields/preview`,
       {
+        configuration,
+      },
+      config
+    );
+  }
+
+  async previewConnectorFieldOptions(
+    connectorName: string,
+    field: string,
+    configuration: Record<string, unknown>,
+    config?: AxiosRequestConfig
+  ): Promise<ConnectorFieldOptionResponseApiDto[]> {
+    return this.post<ConnectorFieldOptionResponseApiDto[]>(
+      `/${connectorName}/options/preview`,
+      {
+        field,
         configuration,
       },
       config

--- a/apps/web/src/features/connectors/shared/api/types/response/connector.response.dto.ts
+++ b/apps/web/src/features/connectors/shared/api/types/response/connector.response.dto.ts
@@ -19,6 +19,8 @@ export interface ConnectorSpecificationItemResponseApiDto {
   placeholder?: string;
   minimum?: number;
   attributes?: string[];
+  /** Fields that must be filled before this field's dynamic options can be loaded. */
+  optionsDependsOn?: string[];
 }
 
 export interface ConnectorSpecificationOneOfResponseApiDto {
@@ -40,6 +42,12 @@ export interface ConnectorFieldResponseApiDto {
   name: string;
   type?: string;
   description?: string;
+}
+
+/** One allowed value of a configuration field declared with DYNAMIC_OPTIONS. */
+export interface ConnectorFieldOptionResponseApiDto {
+  value: string;
+  label: string;
 }
 
 export interface ConnectorFieldsResponseApiDto {

--- a/apps/web/src/features/connectors/shared/enums/connector-specification-attribute.enum.ts
+++ b/apps/web/src/features/connectors/shared/enums/connector-specification-attribute.enum.ts
@@ -3,4 +3,5 @@ export enum ConnectorSpecificationAttribute {
   HIDE_IN_CONFIG_FORM = 'HIDE_IN_CONFIG_FORM',
   DEPRECATED = 'DEPRECATED',
   PINNED = 'PINNED',
+  DYNAMIC_OPTIONS = 'DYNAMIC_OPTIONS',
 }

--- a/apps/web/src/features/connectors/shared/model/hooks/useConnectorFieldOptions.test.tsx
+++ b/apps/web/src/features/connectors/shared/model/hooks/useConnectorFieldOptions.test.tsx
@@ -1,0 +1,166 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ConnectorFieldOptionResponseApiDto } from '../../api';
+import { ConnectorApiService } from '../../api';
+import { useConnectorFieldOptions } from './useConnectorFieldOptions';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+const sheets: ConnectorFieldOptionResponseApiDto[] = [
+  { value: 'Summary', label: 'Summary' },
+  { value: 'Data', label: 'Data' },
+];
+
+describe('useConnectorFieldOptions', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('waits until every dependency is filled and then loads the options once', async () => {
+    const previewSpy = vi
+      .spyOn(ConnectorApiService.prototype, 'previewConnectorFieldOptions')
+      .mockResolvedValue(sheets);
+
+    const { result, rerender } = renderHook(
+      ({ configuration }: { configuration: Record<string, unknown> }) =>
+        useConnectorFieldOptions({
+          connectorName: 'GoogleSheets',
+          field: 'SheetName',
+          configuration,
+          dependsOn: ['SpreadsheetId'],
+        }),
+      { initialProps: { configuration: { SpreadsheetId: '' } as Record<string, unknown> } }
+    );
+
+    expect(result.current.status).toBe('waiting');
+    expect(previewSpy).not.toHaveBeenCalled();
+
+    rerender({ configuration: { SpreadsheetId: 'sheet-1', HeaderRow: 1 } });
+    expect(result.current.status).toBe('loading');
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('loaded');
+    });
+    expect(result.current.options).toEqual(sheets);
+    expect(previewSpy).toHaveBeenCalledTimes(1);
+    expect(previewSpy).toHaveBeenCalledWith(
+      'GoogleSheets',
+      'SheetName',
+      { SpreadsheetId: 'sheet-1', HeaderRow: 1 },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+
+    rerender({ configuration: { SpreadsheetId: 'sheet-1', HeaderRow: 2 } });
+    await new Promise(resolve => setTimeout(resolve, 500));
+    expect(previewSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe('loaded');
+  });
+
+  it('drops the stale response when a dependency changes while loading', async () => {
+    const first = deferred<ConnectorFieldOptionResponseApiDto[]>();
+    const second = deferred<ConnectorFieldOptionResponseApiDto[]>();
+    vi.spyOn(ConnectorApiService.prototype, 'previewConnectorFieldOptions')
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const { result, rerender } = renderHook(
+      ({ configuration }: { configuration: Record<string, unknown> }) =>
+        useConnectorFieldOptions({
+          connectorName: 'GoogleSheets',
+          field: 'SheetName',
+          configuration,
+          dependsOn: ['SpreadsheetId'],
+        }),
+      { initialProps: { configuration: { SpreadsheetId: 'sheet-1' } as Record<string, unknown> } }
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+    rerender({ configuration: { SpreadsheetId: 'sheet-2' } });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    await act(async () => {
+      first.resolve([{ value: 'Old', label: 'Old' }]);
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe('loading');
+
+    await act(async () => {
+      second.resolve(sheets);
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(result.current.status).toBe('loaded');
+    });
+    expect(result.current.options).toEqual(sheets);
+  });
+
+  it('prefers the backend message and opts out of the global error toast', async () => {
+    const previewSpy = vi
+      .spyOn(ConnectorApiService.prototype, 'previewConnectorFieldOptions')
+      .mockRejectedValue({
+        response: {
+          status: 400,
+          data: { message: 'Connector credentials are invalid or expired' },
+        },
+      });
+
+    const { result } = renderHook(() =>
+      useConnectorFieldOptions({
+        connectorName: 'GoogleSheets',
+        field: 'SheetName',
+        configuration: { SpreadsheetId: 'sheet-1' },
+        dependsOn: ['SpreadsheetId'],
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+    expect(result.current.error).toBe('Connector credentials are invalid or expired');
+    expect(previewSpy).toHaveBeenCalledWith(
+      'GoogleSheets',
+      'SheetName',
+      { SpreadsheetId: 'sheet-1' },
+      expect.objectContaining({ skipErrorToast: true, skipLoadingIndicator: true })
+    );
+  });
+
+  it('exposes the failure and reloads on demand', async () => {
+    const previewSpy = vi
+      .spyOn(ConnectorApiService.prototype, 'previewConnectorFieldOptions')
+      .mockRejectedValueOnce(new Error('Google Sheets access denied'))
+      .mockResolvedValueOnce(sheets);
+
+    const { result } = renderHook(() =>
+      useConnectorFieldOptions({
+        connectorName: 'GoogleSheets',
+        field: 'SheetName',
+        configuration: { SpreadsheetId: 'sheet-1' },
+        dependsOn: ['SpreadsheetId'],
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error');
+    });
+    expect(result.current.error).toBe('Google Sheets access denied');
+    expect(result.current.options).toEqual([]);
+
+    act(() => {
+      result.current.reload();
+    });
+    await waitFor(() => {
+      expect(result.current.status).toBe('loaded');
+    });
+    expect(result.current.options).toEqual(sheets);
+    expect(previewSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/features/connectors/shared/model/hooks/useConnectorFieldOptions.ts
+++ b/apps/web/src/features/connectors/shared/model/hooks/useConnectorFieldOptions.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ConnectorApiService } from '../../api/connector-api.service';
+import { extractApiError } from '../../../../../app/api';
+import type { ConnectorFieldOptionResponseApiDto } from '../../api/types/response';
+import {
+  areDynamicOptionDependenciesReady,
+  getDynamicOptionsDependencyKey,
+} from '../../utils/dynamic-options.utils';
+
+export const DYNAMIC_OPTIONS_DEBOUNCE_MS = 400;
+
+interface UseConnectorFieldOptionsParams {
+  connectorName: string;
+  field: string;
+  configuration: Record<string, unknown>;
+  dependsOn?: string[];
+}
+
+export type ConnectorFieldOptionsStatus = 'waiting' | 'loading' | 'loaded' | 'error';
+
+export interface ConnectorFieldOptionsState {
+  status: ConnectorFieldOptionsStatus;
+  options: ConnectorFieldOptionResponseApiDto[];
+  error: string | null;
+  /** Dependency key the current `options` were loaded for. */
+  loadedKey: string | null;
+  reload: () => void;
+}
+
+/**
+ * Loads the allowed values of a DYNAMIC_OPTIONS configuration field from the
+ * backend once every field it depends on is filled. Reloads only when those
+ * dependencies change, debounces typing, and drops stale responses.
+ */
+export function useConnectorFieldOptions({
+  connectorName,
+  field,
+  configuration,
+  dependsOn,
+}: UseConnectorFieldOptionsParams): ConnectorFieldOptionsState {
+  const dependencyKey = getDynamicOptionsDependencyKey(configuration, dependsOn);
+  const dependenciesReady = areDynamicOptionDependenciesReady(configuration, dependsOn);
+
+  const [status, setStatus] = useState<ConnectorFieldOptionsStatus>('waiting');
+  const [options, setOptions] = useState<ConnectorFieldOptionResponseApiDto[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loadedKey, setLoadedKey] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const requestIdRef = useRef(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const configurationRef = useRef(configuration);
+  configurationRef.current = configuration;
+
+  const reload = useCallback(() => {
+    setReloadToken(token => token + 1);
+  }, []);
+
+  useEffect(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+
+    if (!dependenciesReady) {
+      requestIdRef.current += 1;
+      setStatus('waiting');
+      setOptions([]);
+      setError(null);
+      setLoadedKey(null);
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setStatus('loading');
+    setError(null);
+
+    const timeout = setTimeout(() => {
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      void new ConnectorApiService()
+        .previewConnectorFieldOptions(connectorName, field, configurationRef.current, {
+          signal: abortController.signal,
+          // The field renders the failure inline; a background lookup must not
+          // toast or flash the global loading indicator while the user types.
+          skipErrorToast: true,
+          skipLoadingIndicator: true,
+        })
+        .then(response => {
+          if (requestId !== requestIdRef.current) return;
+          setOptions(response);
+          setLoadedKey(dependencyKey);
+          setStatus('loaded');
+        })
+        .catch((requestError: unknown) => {
+          if (requestId !== requestIdRef.current || abortController.signal.aborted) return;
+          setOptions([]);
+          setLoadedKey(null);
+          setError(
+            extractApiError(requestError).message ??
+              (requestError instanceof Error ? requestError.message : 'Unknown error')
+          );
+          setStatus('error');
+        })
+        .finally(() => {
+          if (requestId === requestIdRef.current) {
+            abortControllerRef.current = null;
+          }
+        });
+    }, DYNAMIC_OPTIONS_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+    // `configuration` is intentionally read through a ref: only the dependency
+    // values (folded into `dependencyKey`) may trigger a new request.
+  }, [connectorName, field, dependencyKey, dependenciesReady, reloadToken]);
+
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+      abortControllerRef.current?.abort();
+    },
+    []
+  );
+
+  return { status, options, error, loadedKey, reload };
+}

--- a/apps/web/src/features/connectors/shared/utils/dynamic-options.utils.test.ts
+++ b/apps/web/src/features/connectors/shared/utils/dynamic-options.utils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  areDynamicOptionDependenciesReady,
+  getDynamicOptionsDependencyKey,
+  hasDynamicOptions,
+} from './dynamic-options.utils';
+
+describe('dynamic options utils', () => {
+  it('detects the DYNAMIC_OPTIONS attribute', () => {
+    expect(hasDynamicOptions({ name: 'SheetName', attributes: ['DYNAMIC_OPTIONS'] })).toBe(true);
+    expect(hasDynamicOptions({ name: 'SheetName', attributes: ['ADVANCED'] })).toBe(false);
+    expect(hasDynamicOptions({ name: 'SheetName' })).toBe(false);
+  });
+
+  it('is ready only when every dependency carries a value', () => {
+    const dependsOn = ['AuthType', 'SpreadsheetId'];
+
+    expect(areDynamicOptionDependenciesReady({}, dependsOn)).toBe(false);
+    expect(areDynamicOptionDependenciesReady({ SpreadsheetId: 'sheet-1' }, dependsOn)).toBe(false);
+    expect(
+      areDynamicOptionDependenciesReady(
+        { AuthType: { oauth2: {} }, SpreadsheetId: 'sheet-1' },
+        dependsOn
+      )
+    ).toBe(false);
+    expect(
+      areDynamicOptionDependenciesReady(
+        { AuthType: { oauth2: { _source_credential_id: 'cred-1' } }, SpreadsheetId: '   ' },
+        dependsOn
+      )
+    ).toBe(false);
+    expect(
+      areDynamicOptionDependenciesReady(
+        { AuthType: { oauth2: { _source_credential_id: 'cred-1' } }, SpreadsheetId: 'sheet-1' },
+        dependsOn
+      )
+    ).toBe(true);
+    expect(
+      areDynamicOptionDependenciesReady(
+        {
+          AuthType: { service_account: { ServiceAccountKey: '**********' } },
+          SpreadsheetId: 'https://docs.google.com/spreadsheets/d/sheet-1/edit',
+        },
+        dependsOn
+      )
+    ).toBe(true);
+  });
+
+  it('treats a field without dependencies as always ready', () => {
+    expect(areDynamicOptionDependenciesReady({}, undefined)).toBe(true);
+    expect(areDynamicOptionDependenciesReady({}, [])).toBe(true);
+  });
+
+  it('changes the dependency key only when a dependency changes', () => {
+    const dependsOn = ['SpreadsheetId'];
+    const base = getDynamicOptionsDependencyKey({ SpreadsheetId: 'a', HeaderRow: 1 }, dependsOn);
+
+    expect(getDynamicOptionsDependencyKey({ SpreadsheetId: 'a', HeaderRow: 5 }, dependsOn)).toBe(
+      base
+    );
+    expect(
+      getDynamicOptionsDependencyKey({ SpreadsheetId: 'b', HeaderRow: 1 }, dependsOn)
+    ).not.toBe(base);
+  });
+});

--- a/apps/web/src/features/connectors/shared/utils/dynamic-options.utils.ts
+++ b/apps/web/src/features/connectors/shared/utils/dynamic-options.utils.ts
@@ -1,0 +1,65 @@
+import type { ConnectorSpecificationResponseApiDto } from '../api/types/response';
+import { ConnectorSpecificationAttribute } from '../enums/connector-specification-attribute.enum';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasMeaningfulValue(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.trim() !== '';
+  if (typeof value === 'number') return !Number.isNaN(value);
+  if (Array.isArray(value)) return value.length > 0;
+  if (isRecord(value)) return Object.values(value).some(hasMeaningfulValue);
+  return true;
+}
+
+/**
+ * A `oneOf` dependency (for example `AuthType`) is ready once one option is
+ * selected and that option carries at least one value: a managed OAuth
+ * credential reference, a pasted secret, or a masked secret of a saved config.
+ */
+function isOneOfDependencyReady(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const [selectedOption] = Object.keys(value);
+  if (!selectedOption) return false;
+  return hasMeaningfulValue(value[selectedOption]);
+}
+
+export function hasDynamicOptions(specification: ConnectorSpecificationResponseApiDto): boolean {
+  return (
+    specification.attributes?.includes(ConnectorSpecificationAttribute.DYNAMIC_OPTIONS) ?? false
+  );
+}
+
+/**
+ * Tells whether every field the dynamic options depend on has a usable value,
+ * so the options request has a chance to succeed.
+ */
+export function areDynamicOptionDependenciesReady(
+  configuration: Record<string, unknown>,
+  dependsOn: string[] | undefined
+): boolean {
+  if (!dependsOn || dependsOn.length === 0) return true;
+
+  return dependsOn.every(dependency => {
+    const value = configuration[dependency];
+    return isRecord(value) ? isOneOfDependencyReady(value) : hasMeaningfulValue(value);
+  });
+}
+
+/**
+ * Stable key of the dependency values: options are reloaded only when it changes,
+ * so edits to unrelated fields never trigger a new provider request.
+ */
+export function getDynamicOptionsDependencyKey(
+  configuration: Record<string, unknown>,
+  dependsOn: string[] | undefined
+): string {
+  const picked = (dependsOn ?? []).reduce<Record<string, unknown>>((acc, dependency) => {
+    acc[dependency] = configuration[dependency];
+    return acc;
+  }, {});
+
+  return JSON.stringify(picked);
+}

--- a/packages/connectors/src/Constants/CommonConstants.js
+++ b/packages/connectors/src/Constants/CommonConstants.js
@@ -10,12 +10,12 @@ var EXECUTION_STATUS = {
   CLEANUP_IN_PROGRESS: 2,
   IMPORT_DONE: 3,
   CLEANUP_DONE: 4,
-  ERROR: 5
+  ERROR: 5,
 };
 
 var RUN_CONFIG_TYPE = {
   INCREMENTAL: 'INCREMENTAL',
-  MANUAL_BACKFILL: 'MANUAL_BACKFILL'
+  MANUAL_BACKFILL: 'MANUAL_BACKFILL',
 };
 
 var CONFIG_ATTRIBUTES = {
@@ -26,6 +26,9 @@ var CONFIG_ATTRIBUTES = {
   OAUTH_FLOW: 'OAUTH_FLOW',
   DEPRECATED: 'DEPRECATED',
   PINNED: 'PINNED',
+  // The field's allowed values come from the source at configuration time
+  // (see AbstractSource.fetchFieldOptions), not from a static `options` list.
+  DYNAMIC_OPTIONS: 'DYNAMIC_OPTIONS',
 };
 
 var OAUTH_CONSTANTS = {

--- a/packages/connectors/src/Sources/GoogleSheets/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/GoogleSheets/GETTING_STARTED.md
@@ -3,13 +3,13 @@
 1. Create a Data Mart with the Google Sheets source.
 2. Authorize Google Sheets access with OAuth or Service Account JSON.
 3. Choose the spreadsheet with Google Picker for OAuth, or provide its ID or URL for a service account.
-4. Provide the sheet tab name.
+4. Pick the sheet tab from the list that loads once the spreadsheet is known. If the list cannot be loaded, type the tab name.
 5. Click Next to preview detected columns from the configured header row.
 6. Keep all-columns mode enabled, or switch to explicit subset mode and choose columns.
 7. Choose a storage table.
 8. Run a refresh to materialize the sheet into storage.
 
-The connector treats row 1 as headers by default. `HeaderRow` is an absolute, one-based sheet row. If `Range` is `A5:D` and its first row contains headers, set `HeaderRow` to `5`. Blank header cells receive generated names such as `column_2`.
+The connector treats row 1 as headers by default. `HeaderRow` and `Range` live under Advanced Settings. `HeaderRow` is an absolute, one-based sheet row. If `Range` is `A5:D` and its first row contains headers, set `HeaderRow` to `5`. Blank header cells receive generated names such as `column_2`.
 
 By default, `ImportAllColumns` is `true`, so every refresh imports all current columns and automatically includes schema additions. The web configuration persists `ImportAllColumns: false` only when the user chooses an explicit subset; runtime `Fields` tracks the latest materialized schema.
 

--- a/packages/connectors/src/Sources/GoogleSheets/README.md
+++ b/packages/connectors/src/Sources/GoogleSheets/README.md
@@ -23,7 +23,13 @@ Generated field identifiers contain only lowercase ASCII letters, digits, and un
 
 The preview lists `_owox_row_number` and `_owox_imported_at` alongside sheet fields. `_owox_row_number` is the only unique key and is always imported. `_owox_imported_at` is optional: it appears in runtime rows, schema, and reported fields only when selected in `Fields`. `ImportAllColumns` controls sheet columns and does not override this technical-field choice.
 
+## Sheet tab selection
+
+`SheetName` is a dynamic-options field: once the spreadsheet is known (picked with Google Picker for OAuth, or entered as an ID or URL for a service account), the setup wizard lists the spreadsheet's tabs through the connector's `fetchFieldOptions('SheetName')` method, which reads `spreadsheets.get` with `fields=sheets.properties`. The list needs no permissions beyond the ones the import already uses. When the list cannot be loaded, the tab name can still be typed.
+
 ## Ranges and headers
+
+`HeaderRow` and `Range` are advanced settings: most sheets keep their headers in row 1 and import the whole tab, so the wizard shows them under Advanced Settings.
 
 `HeaderRow` is always the absolute row number in the sheet, including when `Range` starts below row 1. For example, with `Range` set to `B5:F` and headers on the first row of that range, set `HeaderRow` to `5`.
 

--- a/packages/connectors/src/Sources/GoogleSheets/Source.js
+++ b/packages/connectors/src/Sources/GoogleSheets/Source.js
@@ -163,7 +163,10 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
           isRequired: true,
           requiredType: 'string',
           label: 'Sheet Name',
-          description: 'Name of the sheet tab to import. One Data Mart imports one sheet tab.',
+          description:
+            'Sheet tab to import. The list is loaded from the selected spreadsheet. One Data Mart imports one sheet tab.',
+          attributes: [CONFIG_ATTRIBUTES.DYNAMIC_OPTIONS],
+          optionsDependsOn: ['AuthType', 'SpreadsheetId'],
         },
         Range: {
           requiredType: 'string',
@@ -171,6 +174,7 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
           label: 'Range',
           description:
             'Optional A1 range inside the selected sheet, for example A:D. Leave empty to import the used range.',
+          attributes: [CONFIG_ATTRIBUTES.ADVANCED],
         },
         HeaderRow: {
           isRequired: true,
@@ -180,6 +184,7 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
           label: 'Header Row',
           description:
             'One-based row number containing column names. The rows below it are imported as data.',
+          attributes: [CONFIG_ATTRIBUTES.ADVANCED],
         },
         InferTypes: {
           requiredType: 'boolean',
@@ -382,6 +387,41 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
     return this._buildFieldsSchema(schema);
   }
 
+  /**
+   * Lists the values a configuration field can take, resolved from the selected
+   * spreadsheet. Only `SheetName` is dynamic: it returns the spreadsheet's tabs.
+   *
+   * @param {string} fieldName - Configuration field declared with DYNAMIC_OPTIONS
+   * @param {AbortSignal} [signal] - Cancels the provider request
+   * @returns {Promise<Array<{value: string, label: string}>>}
+   */
+  async fetchFieldOptions(fieldName, signal) {
+    if (fieldName !== 'SheetName') {
+      throw new ConnectorConfigurationException(
+        `Field '${fieldName}' does not provide dynamic options`
+      );
+    }
+
+    return this._fetchSheetTabs(signal);
+  }
+
+  async _fetchSheetTabs(signal) {
+    const spreadsheetId = this._extractSpreadsheetId(this.config.SpreadsheetId?.value);
+    const encodedSpreadsheetId = encodeURIComponent(spreadsheetId);
+    const url =
+      `https://sheets.googleapis.com/v4/spreadsheets/${encodedSpreadsheetId}` +
+      '?fields=sheets.properties(sheetId,title,index)';
+
+    const payload = await this._fetchSheetsApiJson(url, { signal });
+    const sheets = Array.isArray(payload.sheets) ? payload.sheets : [];
+
+    return sheets
+      .map(sheet => sheet?.properties)
+      .filter(properties => typeof properties?.title === 'string' && properties.title !== '')
+      .sort((left, right) => (left.index ?? 0) - (right.index ?? 0))
+      .map(properties => ({ value: properties.title, label: properties.title }));
+  }
+
   async _fetchSheetValues({ preview = false, signal } = {}) {
     const spreadsheetId = this._extractSpreadsheetId(this.config.SpreadsheetId.value);
     const encodedSpreadsheetId = encodeURIComponent(spreadsheetId);
@@ -391,6 +431,16 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
       `https://sheets.googleapis.com/v4/spreadsheets/${encodedSpreadsheetId}/values/${encodedRange}` +
       '?majorDimension=ROWS&valueRenderOption=UNFORMATTED_VALUE&dateTimeRenderOption=FORMATTED_STRING';
 
+    const payload = await this._fetchSheetsApiJson(url, { signal });
+    return Array.isArray(payload.values) ? payload.values : [];
+  }
+
+  /**
+   * Performs an authorized Google Sheets API request and parses its JSON body.
+   * Refreshes the access token and retries once on HTTP 401, enforces the
+   * response size limit, and wraps provider failures into HttpRequestException.
+   */
+  async _fetchSheetsApiJson(url, { signal } = {}) {
     for (let authorizationAttempt = 0; authorizationAttempt < 2; authorizationAttempt += 1) {
       try {
         signal?.throwIfAborted();
@@ -414,8 +464,7 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
             'Google Sheets response exceeds the 50 MB import limit. Narrow the Range and try again.'
           );
         }
-        const payload = JSON.parse(responseText);
-        return Array.isArray(payload.values) ? payload.values : [];
+        return JSON.parse(responseText);
       } catch (error) {
         if (signal?.aborted) {
           throw signal.reason || error;
@@ -683,6 +732,9 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
 
   _extractSpreadsheetId(value) {
     const rawValue = String(value || '').trim();
+    if (rawValue === '') {
+      throw new ConnectorConfigurationException('Spreadsheet ID or URL is required');
+    }
     const match = rawValue.match(/\/spreadsheets\/d\/([A-Za-z0-9_-]+)/);
     const spreadsheetId = match ? match[1] : rawValue;
 

--- a/packages/connectors/test/GoogleSheets.test.js
+++ b/packages/connectors/test/GoogleSheets.test.js
@@ -89,6 +89,7 @@ const GoogleSheetsSource = loadScript(
       ADVANCED: 'ADVANCED',
       HIDE_IN_CONFIG_FORM: 'HIDE_IN_CONFIG_FORM',
       OAUTH_FLOW: 'OAUTH_FLOW',
+      DYNAMIC_OPTIONS: 'DYNAMIC_OPTIONS',
     },
     OAUTH_CONSTANTS: {
       UI: 'UI',
@@ -671,4 +672,106 @@ test('connector always publishes empty snapshots and reports only the runtime sc
     'sheet _owox_row_number, sheet _owox_imported_at, sheet name'
   );
   assert.deepEqual(replacements, [[]]);
+});
+
+test('declares Sheet Name as a dynamic-options field and keeps Header Row and Range advanced', () => {
+  let mergedParameters;
+  const config = {
+    mergeParameters(parameters) {
+      mergedParameters = parameters;
+      return this;
+    },
+  };
+
+  new GoogleSheetsSource(config);
+
+  assert.deepEqual(plain(mergedParameters.SheetName.attributes), ['DYNAMIC_OPTIONS']);
+  assert.deepEqual(plain(mergedParameters.SheetName.optionsDependsOn), [
+    'AuthType',
+    'SpreadsheetId',
+  ]);
+  assert.deepEqual(plain(mergedParameters.HeaderRow.attributes), ['ADVANCED']);
+  assert.deepEqual(plain(mergedParameters.Range.attributes), ['ADVANCED']);
+  assert.equal(mergedParameters.HeaderRow.isRequired, true);
+  assert.equal(mergedParameters.HeaderRow.default, 1);
+});
+
+test('lists the spreadsheet tabs in sheet order as Sheet Name options', async () => {
+  const source = createSource();
+  const requestedUrls = [];
+  source.getAccessToken = async () => 'token';
+  source._fetchSheetResponse = async url => {
+    requestedUrls.push(url);
+    return {
+      getContentText: async () =>
+        JSON.stringify({
+          sheets: [
+            { properties: { sheetId: 7, title: 'Targets', index: 2 } },
+            { properties: { sheetId: 0, title: 'Summary', index: 0 } },
+            { properties: { sheetId: 3, title: 'Data', index: 1 } },
+            { properties: { sheetId: 9, index: 3 } },
+          ],
+        }),
+    };
+  };
+
+  const options = await source.fetchFieldOptions('SheetName');
+
+  assert.deepEqual(plain(options), [
+    { value: 'Summary', label: 'Summary' },
+    { value: 'Data', label: 'Data' },
+    { value: 'Targets', label: 'Targets' },
+  ]);
+  assert.equal(requestedUrls.length, 1);
+  assert.match(
+    requestedUrls[0],
+    /^https:\/\/sheets\.googleapis\.com\/v4\/spreadsheets\/spreadsheet-id\?fields=sheets\.properties/
+  );
+});
+
+test('refreshes a rejected token once while listing spreadsheet tabs', async () => {
+  const source = createSource();
+  const tokenCalls = [];
+  let requestCount = 0;
+  source.getAccessToken = async options => {
+    tokenCalls.push(options.forceRefresh);
+    return 'token';
+  };
+  source._fetchSheetResponse = async () => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      throw new HttpRequestException({ message: 'Unauthorized', statusCode: 401 });
+    }
+    return {
+      getContentText: async () =>
+        JSON.stringify({ sheets: [{ properties: { title: 'Data', index: 0 } }] }),
+    };
+  };
+
+  assert.deepEqual(plain(await source.fetchFieldOptions('SheetName')), [
+    { value: 'Data', label: 'Data' },
+  ]);
+  assert.deepEqual(tokenCalls, [false, true]);
+});
+
+test('requires the spreadsheet before listing its tabs', async () => {
+  const source = createSource();
+  source.config.SpreadsheetId = { value: '' };
+  source.getAccessToken = async () => assert.fail('token should not be requested');
+
+  await assert.rejects(source.fetchFieldOptions('SheetName'), error => {
+    assert.ok(error instanceof ConnectorConfigurationException);
+    assert.match(error.message, /Spreadsheet ID or URL is required/);
+    return true;
+  });
+});
+
+test('rejects dynamic options for fields that do not provide them', async () => {
+  const source = createSource();
+
+  await assert.rejects(source.fetchFieldOptions('Range'), error => {
+    assert.ok(error instanceof ConnectorConfigurationException);
+    assert.match(error.message, /'Range' does not provide dynamic options/);
+    return true;
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to the Google Sheets source connector setup form after the OAuth feature demo:

- **Sheet Name is picked from the spreadsheet's tabs.** Once the spreadsheet is known (Google Picker for OAuth, ID/URL for a service account) the wizard lists its tabs; the value is stored as before. If the list cannot be loaded the field falls back to free-text input with the provider error and a Retry action, so the user is never blocked.
- **No "Spreadsheet ID or URL" input under managed OAuth.** The spreadsheet is chosen with Google Picker in that mode, so the manual input stays hidden while the OAuth settings load, before sign-in and after picking. It still appears for Service Account and for manual OAuth credentials.
- **Header Row and Range moved to Advanced Settings.** Most sheets keep their headers in row 1 and import the whole tab; the defaults are unchanged.

## How it works

The connector contract gains a generic way to declare **dynamic options** for a configuration field:

- `packages/connectors`: new `CONFIG_ATTRIBUTES.DYNAMIC_OPTIONS` plus `optionsDependsOn` on the field; a source implements `fetchFieldOptions(fieldName, signal)`. `GoogleSheetsSource` implements it for `SheetName` with `spreadsheets.get?fields=sheets.properties`, reusing the same authorized request path (token refresh on 401, size guard, error mapping) as the values request, which is now shared through `_fetchSheetsApiJson`.
- `apps/backend`: new `POST /api/connectors/:connectorName/options/preview` (`{ field, configuration }` → `[{ value, label }]`). The whole configuration is deliberately **not** validated up front, because the caller is still filling the form; the source reports what is missing (for example "Spreadsheet ID or URL is required"). Credential injection, the 15 s timeout and the provider→HTTP error mapping are shared with the fields preview through `connector-preview-support.ts`. The specification DTO exposes `optionsDependsOn`.
- `apps/web`: `ConfigurationDynamicOptionsField` + `useConnectorFieldOptions` render a combobox for `DYNAMIC_OPTIONS` fields, load the options once every `optionsDependsOn` field has a value (debounced, stale responses dropped), clear a value that no longer exists in the freshly loaded list, and fall back to a text input on error.

### Root cause of the visible "Spreadsheet ID or URL" input

Two things made the input show up on a fresh OAuth configuration:

1. `OauthRenderFactory` reported "not managed" (and rendered the manual credential fields) while `GET /oauth/settings` was still loading. It now treats the loading state as the managed flow, renders a short loading note instead of the manual fields, and reports manual mode when it unmounts (another auth option was selected).
2. `ConfigurationOneOfRender` seeds `AuthType: { oauth2: {} }` in a mount effect, but the parent `ConfigurationStep` re-seeds its state from `initialConfiguration` right after and dropped that write, so `AuthType` stayed unset until the user touched the form. `ConfigurationStep` now seeds the first `oneOf` option itself, and the hide rule also trusts an explicit "managed" report from the renderer.

## Tests

- `packages/connectors`: `GoogleSheets.test.js` — spec attributes, tab listing in sheet order, 401 refresh while listing, missing spreadsheet, unsupported field.
- `apps/backend`: `connector-field-options-preview.service.spec.ts` (success without full validation, unsupported connector, configuration errors, credential failures pass-through, 401→400, 5xx→502, malformed response, timeout) and e2e cases in `connector-fields.e2e-spec.ts` for the new endpoint.
- `apps/web`: `dynamic-options.utils.test.ts`, `useConnectorFieldOptions.test.tsx`, and `ConfigurationStep.test.tsx` cases for the hidden input (loading, signed-out, fresh configuration, manual mode) and the dynamic Sheet Name field (waiting, loaded, stale value cleared, error fallback).

Verified locally in the setup wizard: Google Sheets → OAuth2 tab shows only the sign-in block and the Sheet Name picker; Service Account tab shows the spreadsheet input; Header Row and Range sit under Advanced Settings; Sheet Name falls back to text input with the provider error when the tabs cannot be loaded.

## Docs and release

- Connector README / GETTING_STARTED updated.
- Changeset: `.changeset/6950-google-sheets-config-ux.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
