### PR TITLE
fix(ci): prevent Release PR lockfile update failures

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Update package-lock.json
         if: steps.changesets.outputs.hasChangesets == 'true'
-        run: npm run clean:reinstall
+        run: npm install --package-lock-only --ignore-scripts --no-audit --no-fund --loglevel error
 
       - name: Commit fixed changelogs
         if: steps.changesets.outputs.hasChangesets == 'true'


### PR DESCRIPTION
## Summary

- update `package-lock.json` in the Release PR workflow with `npm install --package-lock-only`
- preserve the dependency graph already recorded in the committed lockfile
- avoid the npm Arborist crash triggered by deleting the lockfile and resolving the complete dependency tree from scratch

## Context

The Release PR workflow installs the repository from the committed lockfile with `npm ci`, then runs Changesets to update package versions and changelogs. The following `Update package-lock.json` step previously called `npm run clean:reinstall`.

`clean:reinstall` removes both `node_modules` and `package-lock.json` before running an unrestricted `npm install`. Recent runs consistently fail during that fresh dependency resolution with:

```text
Cannot read properties of null (reading 'edgesOut')
```

The exception comes from npm Arborist while it builds a peer dependency set. The latest failing workflow run is [Release PR #1326](https://github.com/OWOX/owox-data-marts/actions/runs/34610299957).

## Why this preserves the release workflow behavior

The purpose of this step is to synchronize `package-lock.json` with the package manifests generated by Changesets. `npm install --package-lock-only` still reads the updated `package.json` files, resolves any required lockfile changes, and writes `package-lock.json`. The flag only prevents npm from modifying `node_modules`.

For the current Version Packages state, Changesets updates 12 workspace package versions. The new command updates all 12 corresponding lockfile entries. A clean `npm ci` using that generated lockfile then succeeds, confirming that the lockfile remains complete and installable.

The workflow no longer deletes the existing lockfile or incidentally refreshes unrelated transitive dependencies that still satisfy semver ranges. That full graph refresh was not required to synchronize Changesets version metadata and was the operation triggering the npm crash. Dependency updates already present on `main` remain preserved because the command starts from the committed lockfile.

The Changesets action, changelog formatting, package formatting, generated lockfile commit, and push steps remain unchanged. No application code, package API, runtime behavior, or publishing contract is modified.

## Verification

- parsed `.github/workflows/release-pr.yml` successfully as YAML
- `git diff --check`
- ran the new lockfile command on a clean archive of the current `changeset-release/main` branch
- confirmed that the generated lockfile contains all 12 expected workspace version updates and no unrelated dependency changes
- ran a clean `npm ci --ignore-scripts --no-audit --no-fund --loglevel error` against the generated lockfile; it installed 2,590 packages successfully

## Release notes

No changeset is included because this is a CI-only correction with no observable product or operator-facing release impact.
